### PR TITLE
Replace regression test by proper unit tests for slice functions.

### DIFF
--- a/pysingfel/constants.py
+++ b/pysingfel/constants.py
@@ -22,6 +22,9 @@ quatz = np.array([0., 0., 0., 1.])
 quatx90 = np.array([1., 1., 0., 0.]) / np.sqrt(2)
 quaty90 = np.array([1., 0., 1., 0.]) / np.sqrt(2)
 quatz90 = np.array([1., 0., 0., 1.]) / np.sqrt(2)
+quatx270 = np.array([1., -1., 0., 0.]) / np.sqrt(2)
+quaty270 = np.array([1., 0., -1., 0.]) / np.sqrt(2)
+quatz270 = np.array([1., 0., 0., -1.]) / np.sqrt(2)
 
 
 vecx = np.array([1., 0., 0.])


### PR DESCRIPTION
These are proper unit tests for the slice functions.
They do not rely on any detector or beam parameters and do not require computing a diffraction pattern.