### PR TITLE
Detectors

### DIFF
--- a/pysingfel/detector/__init__.py
+++ b/pysingfel/detector/__init__.py
@@ -1,4 +1,4 @@
 from .base import DetectorBase
+from .lcls import LCLSDetector
 from .plain import PlainDetector
-from .pnccd import PnccdDetector
 from .user_defined import UserDefinedDetector

--- a/pysingfel/detector/__init__.py
+++ b/pysingfel/detector/__init__.py
@@ -1,4 +1,7 @@
 from .base import DetectorBase
-from .lcls import LCLSDetector
 from .plain import PlainDetector
 from .user_defined import UserDefinedDetector
+
+from .lcls import LCLSDetector
+from .pnccd import PnccdDetector
+from .cspad import CsPadDetector

--- a/pysingfel/detector/__init__.py
+++ b/pysingfel/detector/__init__.py
@@ -5,3 +5,4 @@ from .user_defined import UserDefinedDetector
 from .lcls import LCLSDetector
 from .pnccd import PnccdDetector
 from .cspad import CsPadDetector
+from .epix10k import Epix10kDetector

--- a/pysingfel/detector/cspad.py
+++ b/pysingfel/detector/cspad.py
@@ -1,0 +1,27 @@
+import re
+import six
+
+from pysingfel.util import deprecated
+from .lcls import LCLSDetector
+
+class CsPadDetector(LCLSDetector):
+    def __init__(self, *args, **kwargs):
+        super(CsPadDetector, self).__init__(*args, **kwargs)
+
+    def _get_cbase(self):
+        """Get detector calibration base object.
+
+        Psana 1 only.
+        """
+        from PSCalib.CalibParsBaseCSPadV1 import CalibParsBaseCSPadV1
+        return CalibParsBaseCSPadV1()
+
+    def _get_det_id(self, source):
+        """Get detector ID form source.
+
+        Example: CsPad::CalibV1 -> CxiDs2.0:Cspad.0 => cspad_0002.
+        Psana 2 only.
+        """
+        match = re.match(r"CxiDs(\d)\.0:Cspad\.0", source)
+        number = str.zfill(match.groups()[0], 4)
+        return "cspad_" + number

--- a/pysingfel/detector/epix10k.py
+++ b/pysingfel/detector/epix10k.py
@@ -1,0 +1,17 @@
+import re
+import six
+
+from pysingfel.util import deprecated
+from .lcls import LCLSDetector
+
+class Epix10kDetector(LCLSDetector):
+    def __init__(self, *args, **kwargs):
+        super(Epix10kDetector, self).__init__(*args, **kwargs)
+
+    def _get_cbase(self):
+        """Get detector calibration base object.
+
+        Psana 1 only.
+        """
+        from PSCalib.CalibParsBaseEpix10kaV1 import CalibParsBaseEpix10kaV1
+        return CalibParsBaseEpix10kaV1()

--- a/pysingfel/detector/lcls.py
+++ b/pysingfel/detector/lcls.py
@@ -164,53 +164,39 @@ class LCLSDetector(DetectorBase):
         """
         raise NotImplementedError()
 
+    def _get_calib_constants(self, name):
+        _name = "_" + name
+        attribute = getattr(self, _name)
+        if six.PY3 and attribute is None:
+            attribute = calib_constants(
+                self.det, exp=self.exp, ctype=name,
+                run=self.run_num)[0]
+        setattr(self, _name, attribute)
+        return attribute
+
     @property
     def pedestals(self):
-        if six.PY3 and self._pedestals is None:
-            self._pedestals = calib_constants(
-                self.det, exp=self.exp, ctype="pedestals",
-                run=self.run_num)[0]
-        return self._pedestals
+        return self._get_calib_constants("pedestals")
 
     @property
     def pixel_rms(self):
-        if six.PY3 and self._pixel_rms is None:
-            self._pixel_rms = calib_constants(
-                self.det, exp=self.exp, ctype="pixel_rms",
-                run=self.run_num)[0]
-        return self._pixel_rms
+        return self._get_calib_constants("pixel_rms")
 
     @property
     def pixel_mask(self):
-        if six.PY3 and self._pixel_mask is None:
-            self._pixel_mask = calib_constants(
-                self.det, exp=self.exp, ctype="pixel_mask",
-                run=self.run_num)[0]
-        return self._pixel_mask
+        return self._get_calib_constants("pixel_mask")
 
     @property
     def pixel_bkgd(self):
-        if six.PY3 and self._pixel_bkgd is None:
-            self._pixel_bkgd = calib_constants(
-                self.det, exp=self.exp, ctype="pixel_bkgd",
-                run=self.run_num)[0]
-        return self._pixel_bkgd
+        return self._get_calib_constants("pixel_bkgd")
 
     @property
     def pixel_status(self):
-        if six.PY3 and self._pixel_status is None:
-            self._pixel_status = calib_constants(
-                self.det, exp=self.exp, ctype="pixel_status",
-                run=self.run_num)[0]
-        return self._pixel_status
+        return self._get_calib_constants("pixel_status")
 
     @property
     def pixel_gain(self):
-        if six.PY3 and self._pixel_gain is None:
-            self._pixel_gain = calib_constants(
-                self.det, exp=self.exp, ctype="pixel_gain",
-                run=self.run_num)[0]
-        return self._pixel_gain
+        return self._get_calib_constants("pixel_gain")
 
     def assemble_image_stack(self, image_stack):
         """

--- a/pysingfel/detector/lcls.py
+++ b/pysingfel/detector/lcls.py
@@ -246,7 +246,7 @@ class LCLSDetector(DetectorBase):
         stack_num = image_stack_batch.shape[0]
 
         # construct the image holder:
-        image = np.zeros((stack_num, self.detector_pixel_num_x, self.detector_pixel_num_y))
+        image = xp.zeros((stack_num, self.detector_pixel_num_x, self.detector_pixel_num_y))
         for l in range(self.panel_num):
             idx_map_1 = self.pixel_index_map[l, :, :, 0]
             idx_map_2 = self.pixel_index_map[l, :, :, 1]

--- a/pysingfel/detector/pnccd.py
+++ b/pysingfel/detector/pnccd.py
@@ -1,0 +1,27 @@
+import re
+import six
+
+from pysingfel.util import deprecated
+from .lcls import LCLSDetector
+
+class PnccdDetector(LCLSDetector):
+    def __init__(self, *args, **kwargs):
+        super(PnccdDetector, self).__init__(*args, **kwargs)
+
+    def _get_cbase(self):
+        """Get detector calibration base object.
+
+        Psana 1 only.
+        """
+        from PSCalib.CalibParsBasePnccdV1 import CalibParsBasePnccdV1
+        return CalibParsBasePnccdV1()
+
+    def _get_det_id(self, source):
+        """Get detector ID form source.
+
+        Example: PNCCD::CalibV1 -> Camp.0:pnCCD.1 => pnccd_0001.
+        Psana 2 only.
+        """
+        match = re.match(r"Camp\.0:pnCCD\.(\d)", source)
+        number = str.zfill(match.groups()[0], 4)
+        return "pnccd_" + number


### PR DESCRIPTION
I moved the PnCCD detector logic into a new LCLS detector class.
In that logic, only the "calibration base" (psana 1) and "detector ID" (psana 2) change depending on the detector. These elements are provided by inheritance, but they are only needed to get the calibration constants (pedestals and co.), not for the geometry.

If the detector doesn't need the calibration constants, then it can be created as `LCLSDetector`.
If the calibration constants are needed, then it is necessary to use the right specialized class.