### PR TITLE
Detectors

### DIFF
--- a/pysingfel/detector/__init__.py
+++ b/pysingfel/detector/__init__.py
@@ -1,6 +1,7 @@
 from .base import DetectorBase
 from .plain import PlainDetector
 from .user_defined import UserDefinedDetector
+from .simple_square import SimpleSquareDetector
 
 from .lcls import LCLSDetector
 from .pnccd import PnccdDetector

--- a/pysingfel/detector/base.py
+++ b/pysingfel/detector/base.py
@@ -45,7 +45,7 @@ class DetectorBase(object):
         self.pixel_distance_reciprocal = None  # (m^-1)
 
         # Pixel map
-        self.pixel_index_map = 0
+        self.pixel_index_map = None
         self.detector_pixel_num_x = 1
         self.detector_pixel_num_y = 1
 
@@ -451,6 +451,9 @@ class DetectorBase(object):
         :param image_stack: The [1, num_x, num_y] numpy array.
         :return: The [num_x, num_y] numpy array.
         """
+        if self.pixel_index_map is None:
+            raise RuntimeError(
+                "This detector does not have pixel mapping information.")
         # construct the image holder:
         image = xp.zeros((self.detector_pixel_num_x, self.detector_pixel_num_y))
         for l in range(self.panel_num):
@@ -467,6 +470,10 @@ class DetectorBase(object):
         :param image_stack_batch: The [stack_num, 1, num_x, num_y] numpy array
         :return: The [stack_num, num_x, num_y] numpy array
         """
+        if self.pixel_index_map is None:
+            raise RuntimeError(
+                "This detector does not have pixel mapping information.")
+
         stack_num = image_stack_batch.shape[0]
 
         # construct the image holder:

--- a/pysingfel/detector/base.py
+++ b/pysingfel/detector/base.py
@@ -437,3 +437,38 @@ class DetectorBase(object):
         dist_max = xp.max(self.pixel_distance_reciprocal)
         return pg.get_reciprocal_mesh(voxel_number_1d, dist_max)
 
+    def assemble_image_stack(self, image_stack):
+        """
+        Assemble the image stack into a 2D diffraction pattern.
+        For this specific object, since it only has one panel, the result is to remove the
+        first dimension.
+
+        :param image_stack: The [1, num_x, num_y] numpy array.
+        :return: The [num_x, num_y] numpy array.
+        """
+        # construct the image holder:
+        image = xp.zeros((self.detector_pixel_num_x, self.detector_pixel_num_y))
+        for l in range(self.panel_num):
+            image[self.pixel_index_map[l, :, :, 0],
+                  self.pixel_index_map[l, :, :, 1]] = image_stack[l, :, :]
+
+        return image
+
+    def assemble_image_stack_batch(self, image_stack_batch):
+        """
+        Assemble the image stack batch into a stack of 2D diffraction patterns.
+        For this specific object, since it has only one panel, the result is a simple reshape.
+
+        :param image_stack_batch: The [stack_num, 1, num_x, num_y] numpy array
+        :return: The [stack_num, num_x, num_y] numpy array
+        """
+        stack_num = image_stack_batch.shape[0]
+
+        # construct the image holder:
+        image = xp.zeros((stack_num, self.detector_pixel_num_x, self.detector_pixel_num_y))
+        for l in range(self.panel_num):
+            idx_map_1 = self.pixel_index_map[l, :, :, 0]
+            idx_map_2 = self.pixel_index_map[l, :, :, 1]
+            image[:, idx_map_1, idx_map_2] = image_stack_batch[:, l]
+
+        return image

--- a/pysingfel/detector/base.py
+++ b/pysingfel/detector/base.py
@@ -78,6 +78,11 @@ class DetectorBase(object):
         self.geometry = None
 
     @property
+    def shape(self):
+        """Unassembled detector shape."""
+        return self._shape
+
+    @property
     def pedestals(self):
         return self._pedestals
 

--- a/pysingfel/detector/base.py
+++ b/pysingfel/detector/base.py
@@ -79,6 +79,7 @@ class DetectorBase(object):
 
     @property
     def distance(self):
+        """Sample-detector distance."""
         return self._distance
 
     @distance.setter
@@ -89,7 +90,7 @@ class DetectorBase(object):
                 "detector orientations along the z axis.")
         self.pixel_position[..., 2] *= value/self._distance
         self._distance = value
-        if self._has_beam:
+        if self._has_beam:  # Update pixel_position_reciprocal & co
             self.initialize_pixels_with_beam(beam=self._beam)
 
     @property

--- a/pysingfel/detector/lcls.py
+++ b/pysingfel/detector/lcls.py
@@ -85,14 +85,14 @@ class LCLSDetector(DetectorBase):
         self.panel_num = np.prod(temp[0].shape[:-2])
         self.distance = temp[2].flatten()[0] * 1e-6  # Convert to m
 
-        det_shape = (self.panel_num, temp[0].shape[-2], temp[0].shape[-1])
-        self.pixel_position = xp.zeros(det_shape + (3,))
-        self.pixel_index_map = xp.zeros(det_shape + (2,))
+        self._shape = (self.panel_num, temp[0].shape[-2], temp[0].shape[-1])
+        self.pixel_position = xp.zeros(self._shape + (3,))
+        self.pixel_index_map = xp.zeros(self._shape + (2,))
 
         for n in range(3):
-            self.pixel_position[..., n] = temp[n].reshape(det_shape)
+            self.pixel_position[..., n] = temp[n].reshape(self._shape)
         for n in range(2):
-            self.pixel_index_map[..., n] = temp_index[n].reshape(det_shape)
+            self.pixel_index_map[..., n] = temp_index[n].reshape(self._shape)
 
         self.pixel_index_map = self.pixel_index_map.astype(xp.int64)
 
@@ -187,6 +187,11 @@ class LCLSDetector(DetectorBase):
                                "".format(name))
         setattr(self, _name, attribute)
         return attribute
+
+    @property
+    def shape(self):
+        """Unassembled detector shape."""
+        return self._shape
 
     @property
     def pedestals(self):

--- a/pysingfel/detector/lcls.py
+++ b/pysingfel/detector/lcls.py
@@ -216,39 +216,3 @@ class LCLSDetector(DetectorBase):
     @property
     def pixel_gain(self):
         return self._get_calib_constants("pixel_gain")
-
-    def assemble_image_stack(self, image_stack):
-        """
-        Assemble the image stack into a 2D diffraction pattern.
-        For this specific object, since it only has one panel, the result is to remove the
-        first dimension.
-
-        :param image_stack: The [1, num_x, num_y] numpy array.
-        :return: The [num_x, num_y] numpy array.
-        """
-        # construct the image holder:
-        image = xp.zeros((self.detector_pixel_num_x, self.detector_pixel_num_y))
-        for l in range(self.panel_num):
-            image[self.pixel_index_map[l, :, :, 0],
-                  self.pixel_index_map[l, :, :, 1]] = image_stack[l, :, :]
-
-        return image
-
-    def assemble_image_stack_batch(self, image_stack_batch):
-        """
-        Assemble the image stack batch into a stack of 2D diffraction patterns.
-        For this specific object, since it has only one panel, the result is a simple reshape.
-
-        :param image_stack_batch: The [stack_num, 1, num_x, num_y] numpy array
-        :return: The [stack_num, num_x, num_y] numpy array
-        """
-        stack_num = image_stack_batch.shape[0]
-
-        # construct the image holder:
-        image = xp.zeros((stack_num, self.detector_pixel_num_x, self.detector_pixel_num_y))
-        for l in range(self.panel_num):
-            idx_map_1 = self.pixel_index_map[l, :, :, 0]
-            idx_map_2 = self.pixel_index_map[l, :, :, 1]
-            image[:, idx_map_1, idx_map_2] = image_stack_batch[:, l]
-
-        return image

--- a/pysingfel/detector/lcls.py
+++ b/pysingfel/detector/lcls.py
@@ -77,13 +77,13 @@ class LCLSDetector(DetectorBase):
         self.geometry = GeometryAccess(geom, 0)
         self.run_num = run_num
 
-        # Set coordinate in real space
-        temp = [xp.asarray(t) for t in self.geometry.get_pixel_coords()]
+        # Set coordinate in real space (convert to m)
+        temp = [xp.asarray(t) * 1e-6 for t in self.geometry.get_pixel_coords()]
         temp_index = [xp.asarray(t)
                       for t in self.geometry.get_pixel_coord_indexes()]
 
         self.panel_num = np.prod(temp[0].shape[:-2])
-        self.distance = asnumpy(temp[2].mean()) * 1e-6  # Convert to m
+        self.distance = asnumpy(temp[2].mean())
 
         self._shape = (self.panel_num, temp[0].shape[-2], temp[0].shape[-1])
         self.pixel_position = xp.zeros(self._shape + (3,))

--- a/pysingfel/detector/lcls.py
+++ b/pysingfel/detector/lcls.py
@@ -83,7 +83,7 @@ class LCLSDetector(DetectorBase):
                       for t in self.geometry.get_pixel_coord_indexes()]
 
         self.panel_num = np.prod(temp[0].shape[:-2])
-        self.distance = asnumpy(temp[2].mean())
+        self._distance = float(temp[2].mean())
 
         self._shape = (self.panel_num, temp[0].shape[-2], temp[0].shape[-1])
         self.pixel_position = xp.zeros(self._shape + (3,))

--- a/pysingfel/detector/lcls.py
+++ b/pysingfel/detector/lcls.py
@@ -189,11 +189,6 @@ class LCLSDetector(DetectorBase):
         return attribute
 
     @property
-    def shape(self):
-        """Unassembled detector shape."""
-        return self._shape
-
-    @property
     def pedestals(self):
         return self._get_calib_constants("pedestals")
 

--- a/pysingfel/detector/lcls.py
+++ b/pysingfel/detector/lcls.py
@@ -83,7 +83,7 @@ class LCLSDetector(DetectorBase):
                       for t in self.geometry.get_pixel_coord_indexes()]
 
         self.panel_num = np.prod(temp[0].shape[:-2])
-        self.distance = temp[2].flatten()[0] * 1e-6  # Convert to m
+        self.distance = asnumpy(temp[2].mean()) * 1e-6  # Convert to m
 
         self._shape = (self.panel_num, temp[0].shape[-2], temp[0].shape[-1])
         self.pixel_position = xp.zeros(self._shape + (3,))

--- a/pysingfel/detector/simple_square.py
+++ b/pysingfel/detector/simple_square.py
@@ -12,15 +12,15 @@ from .base import DetectorBase
 
 class SimpleSquareDetector(DetectorBase):
     """
-    Class for simple square detector.
+    Class for a simple square detector.
     """
 
     def __init__(self, N_pixel, det_size, det_distance, beam=None):
         """
         Initialize the detector
-        :param geom:  The dictionary containing all the necessary information to initialize
-                        the detector.
-        :param beam: The beam object
+        :param N_pixel: Number of pixels per dimension.
+        :param det_size: Length of detector sides (m).
+        :param det_distance: Sample-Detector distance (m).
         """
         super(SimpleSquareDetector, self).__init__()
 

--- a/pysingfel/detector/simple_square.py
+++ b/pysingfel/detector/simple_square.py
@@ -37,8 +37,8 @@ class SimpleSquareDetector(DetectorBase):
         self._shape = (1, N_pixel, N_pixel)
 
         # Define all properties the detector should have
-        self.distance = det_distance
-        self.center_z = self.distance * xp.ones(self._shape, dtype=xp.float64)
+        self._distance = det_distance
+        self.center_z = self._distance * xp.ones(self._shape, dtype=xp.float64)
 
         p_center_x = xp.stack((X,))
         p_center_y = xp.stack((Y,))

--- a/pysingfel/detector/simple_square.py
+++ b/pysingfel/detector/simple_square.py
@@ -1,0 +1,77 @@
+import numpy as np
+import os
+import sys
+
+import pysingfel.geometry as pg
+import pysingfel.util as pu
+import pysingfel.crosstalk as pc
+from pysingfel.util import xp, asnumpy
+
+from .base import DetectorBase
+
+
+class SimpleSquareDetector(DetectorBase):
+    """
+    Class for simple square detector.
+    """
+
+    def __init__(self, N_pixel, det_size, det_distance, beam=None):
+        """
+        Initialize the detector
+        :param geom:  The dictionary containing all the necessary information to initialize
+                        the detector.
+        :param beam: The beam object
+        """
+        super(SimpleSquareDetector, self).__init__()
+
+        ar = xp.arange(N_pixel)
+        sep = float(det_size) / N_pixel
+        x = -det_size/2 + sep/2 + ar*sep
+        y = -det_size/2 + sep/2 + ar*sep
+        X, Y = xp.meshgrid(x, y, indexing='xy')
+        Xar, Yar = xp.meshgrid(ar, ar, indexing='xy')
+
+        self.panel_num = 1
+        self.panel_pixel_num_x = N_pixel
+        self.panel_pixel_num_y = N_pixel
+        self._shape = (1, N_pixel, N_pixel)
+
+        # Define all properties the detector should have
+        self.distance = det_distance
+        self.center_z = self.distance * xp.ones(self._shape, dtype=xp.float64)
+
+        p_center_x = xp.stack((X,))
+        p_center_y = xp.stack((Y,))
+        self.pixel_width = sep * xp.ones(self._shape, dtype=xp.float64)
+        self.pixel_height = sep * xp.ones(self._shape, dtype=xp.float64)
+        self.center_x = p_center_x
+        self.center_y = p_center_y
+
+        # construct the the pixel position array
+        self.pixel_position = xp.zeros(self._shape + (3,))
+        self.pixel_position[:, :, :, 0] = self.center_x
+        self.pixel_position[:, :, :, 1] = self.center_y
+        self.pixel_position[:, :, :, 2] = self.center_z
+
+        # Pixel map
+        p_map_x = xp.stack((Xar,))
+        p_map_y = xp.stack((Yar,))
+        # [panel number, pixel num x, pixel num y]
+        self.pixel_index_map = xp.stack((p_map_x, p_map_y), axis=-1)
+        # Detector pixel number info
+        self.detector_pixel_num_x = asnumpy(xp.max(self.pixel_index_map[:, :, :, 0]))
+        self.detector_pixel_num_y = asnumpy(xp.max(self.pixel_index_map[:, :, :, 1]))
+
+        # Panel pixel number info
+        # number of pixels in each panel in x/y direction
+        self.panel_pixel_num_x = self.pixel_index_map.shape[1]
+        self.panel_pixel_num_y = self.pixel_index_map.shape[2]
+
+        # total number of pixels (px*py)
+        self.pixel_num_total = np.prod(self._shape)
+
+        # Calculate the pixel area
+        self.pixel_area = xp.multiply(self.pixel_height, self.pixel_width)
+
+        # Get reciprocal space configurations and corrections.
+        self.initialize_pixels_with_beam(beam=beam)

--- a/pysingfel/detector/tests/test_detector_base.py
+++ b/pysingfel/detector/tests/test_detector_base.py
@@ -5,6 +5,7 @@ import pytest
 import pysingfel as ps
 import pysingfel.gpu as pg
 import pysingfel.constants as cst
+from pysingfel.util import xp
 
 import six
 if six.PY2:
@@ -61,3 +62,19 @@ class TestDetectorBase(object):
     def test_pedestal_nonzero(self):
         """Test existence of pedestals."""
         assert np.sum(abs(self.det.pedestals[:])) > np.finfo(float).eps
+
+
+def test_distance_change():
+    """Test distance property change."""
+    det = ps.SimpleSquareDetector(
+        N_pixel=1024, det_size=0.1, det_distance=0.2)
+    distance_1 = det.distance
+    pixel_position_1 = det.pixel_position.copy()
+    det.distance *= 2
+    assert np.isclose(det.distance, distance_1*2)
+    assert xp.allclose(det.pixel_position[..., 0],
+                       pixel_position_1[..., 0])  # X unchanged
+    assert xp.allclose(det.pixel_position[..., 1],
+                       pixel_position_1[..., 1])  # Y unchanged
+    assert xp.allclose(det.pixel_position[..., 2],
+                       pixel_position_1[..., 2]*2)  # Z doubled

--- a/pysingfel/detector/tests/test_user_defined_detector.py
+++ b/pysingfel/detector/tests/test_user_defined_detector.py
@@ -1,0 +1,69 @@
+import numpy as np
+import os
+import pytest
+
+import pysingfel as ps
+import pysingfel.gpu as pg
+import pysingfel.constants as cst
+from pysingfel.util import xp
+
+
+class TestUserDefinedDetector(object):
+    """Test user defined detector functions."""
+    @classmethod
+    def setup_class(cls):
+        cls.det_shape = (2, 256, 256)
+        cls.gap_size = 1e-2  # m
+        cls.p_map_xpanel_size =  1e-1  # m
+        cls.distance = 0.2  # m
+        ar = np.arange(256)
+        cls.sep = cls.p_map_xpanel_size / 256
+        x = cls.gap_size/2 + cls.sep/2 + ar*cls.sep
+        y = -cls.p_map_xpanel_size/2 + cls.sep/2 + ar*cls.sep
+
+        X, Y = np.meshgrid(x, y, indexing='ij')
+        Xar, Yar = np.meshgrid(ar, ar, indexing='ij')
+
+        p_center_x = np.stack((X-cls.gap_size-cls.p_map_xpanel_size, X))
+        p_center_y = np.stack((Y, Y))
+
+        p_map_x = np.stack((Xar, Xar + 256 + int(cls.gap_size/cls.sep)))
+        p_map_y = np.stack((Yar, Yar))
+
+        p_map = np.stack((p_map_x, p_map_y), axis=-1)
+
+        det_dict = {
+            'panel number': cls.det_shape[0],
+            'panel pixel num x': cls.det_shape[1],
+            'panel pixel num y': cls.det_shape[2],
+            'detector distance': cls.distance,
+            'pixel width': cls.sep * np.ones(cls.det_shape),
+            'pixel height': cls.sep * np.ones(cls.det_shape),
+            'pixel center x': p_center_x,
+            'pixel center y': p_center_y,
+            'pixel map': p_map,
+        }
+
+        cls.det = ps.UserDefinedDetector(geom=det_dict)
+
+    def test_shape(self):
+        assert self.det.shape == self.det_shape
+
+    def test_distance(self):
+        assert np.isclose(self.det.distance, self.distance)
+
+    def test_pixel_position_shape(self):
+        assert self.det.pixel_position.shape == self.det_shape + (3,)
+
+    def test_pixel_position_z(self):
+        assert xp.allclose(self.det.pixel_position[..., 2], self.distance)
+
+    def test_pixel_position_x_sep(self):
+        x_diff = self.det.pixel_position[:, 1:, :, 0] \
+            - self.det.pixel_position[:, :-1, :, 0]
+        assert xp.allclose(x_diff, self.sep)
+
+    def test_pixel_position_y_sep(self):
+        y_diff = self.det.pixel_position[:, :, 1:, 1] \
+            - self.det.pixel_position[:, :, :-1, 1]
+        assert xp.allclose(y_diff, self.sep)

--- a/pysingfel/detector/user_defined.py
+++ b/pysingfel/detector/user_defined.py
@@ -64,8 +64,7 @@ class UserDefinedDetector(DetectorBase):
         self.orientation = np.array([0, 0, 1])
 
         # construct the the pixel position array
-        self.pixel_position = xp.zeros((self.panel_num, self.panel_pixel_num_x,
-                                        self.panel_pixel_num_y, 3))
+        self.pixel_position = xp.zeros(self._shape + (3,))
         self.pixel_position[:, :, :, 2] = self.distance
         self.pixel_position[:, :, :, 0] = self.center_x
         self.pixel_position[:, :, :, 1] = self.center_y
@@ -83,7 +82,7 @@ class UserDefinedDetector(DetectorBase):
         self.panel_pixel_num_y = self.pixel_index_map.shape[2]
 
         # total number of pixels (px*py)
-        self.pixel_num_total = self.panel_num * self.panel_pixel_num_x * self.panel_pixel_num_y
+        self.pixel_num_total = np.prod(self._shape)
 
         ###########################################################################################
         # Do necessary calculation to finishes the initialization

--- a/pysingfel/detector/user_defined.py
+++ b/pysingfel/detector/user_defined.py
@@ -59,18 +59,18 @@ class UserDefinedDetector(DetectorBase):
                        self.panel_pixel_num_y)
 
         # Define all properties the detector should have
-        self.distance = None
+        self._distance = None
         if 'pixel center z' in geom:
             if 'detector distance' in geom:
                 raise ValueError("Please provide one of "
                                  "'pixel center z' or 'detector distance'.")
             self.center_z = xp.asarray(geom['pixel center z'], dtype=xp.float64)
-            self.distance = asnumpy(self.center_z.mean())
+            self._distance = float(self.center_z.mean())
         else:
             if 'detector distance' not in geom:
                 KeyError("Missing required 'detector distance' key.")
-            self.distance = float(geom['detector distance'])
-            self.center_z = self.distance * xp.ones(self._shape,
+            self._distance = float(geom['detector distance'])
+            self.center_z = self._distance * xp.ones(self._shape,
                                                     dtype=xp.float64)
 
         # Below: [panel number, pixel num x, pixel num y]  in (m)

--- a/pysingfel/detector/user_defined.py
+++ b/pysingfel/detector/user_defined.py
@@ -49,6 +49,8 @@ class UserDefinedDetector(DetectorBase):
         self.panel_num = int(geom['panel number'])
         self.panel_pixel_num_x = int(geom['panel pixel num x'])
         self.panel_pixel_num_y = int(geom['panel pixel num y'])
+        self._shape = (self.panel_num, self.panel_pixel_num_x,
+                       self.panel_pixel_num_y)
 
         # Define all properties the detector should have
         self.distance = float(geom['detector distance'])  # detector distance in (m)

--- a/pysingfel/detector/user_defined.py
+++ b/pysingfel/detector/user_defined.py
@@ -16,7 +16,7 @@ class UserDefinedDetector(DetectorBase):
     with a dictionary with proper entries to use this class.
     """
 
-    def __init__(self, geom, beam):
+    def __init__(self, geom, beam=None):
         """
         Initialize the detector
         :param geom:  The dictionary containing all the necessary information to initialize

--- a/pysingfel/detector/user_defined.py
+++ b/pysingfel/detector/user_defined.py
@@ -70,7 +70,7 @@ class UserDefinedDetector(DetectorBase):
             if 'detector distance' not in geom:
                 KeyError("Missing required 'detector distance' key.")
             self.distance = float(geom['detector distance'])
-            self.center_z = self.distance * xp.ones(self._shape + (3,),
+            self.center_z = self.distance * xp.ones(self._shape,
                                                     dtype=xp.float64)
 
         # Below: [panel number, pixel num x, pixel num y]  in (m)
@@ -88,16 +88,17 @@ class UserDefinedDetector(DetectorBase):
         self.pixel_position[:, :, :, 2] = self.center_z
 
         # Pixel map
-        # [panel number, pixel num x, pixel num y]
-        self.pixel_index_map = xp.asarray(geom['pixel map'], dtype=xp.int64)
-        # Detector pixel number info
-        self.detector_pixel_num_x = asnumpy(xp.max(self.pixel_index_map[:, :, :, 0]))
-        self.detector_pixel_num_y = asnumpy(xp.max(self.pixel_index_map[:, :, :, 1]))
+        if 'pixel map' in geom:
+            # [panel number, pixel num x, pixel num y]
+            self.pixel_index_map = xp.asarray(geom['pixel map'], dtype=xp.int64)
+            # Detector pixel number info
+            self.detector_pixel_num_x = asnumpy(xp.max(self.pixel_index_map[:, :, :, 0]))
+            self.detector_pixel_num_y = asnumpy(xp.max(self.pixel_index_map[:, :, :, 1]))
 
-        # Panel pixel number info
-        # number of pixels in each panel in x/y direction
-        self.panel_pixel_num_x = self.pixel_index_map.shape[1]
-        self.panel_pixel_num_y = self.pixel_index_map.shape[2]
+            # Panel pixel number info
+            # number of pixels in each panel in x/y direction
+            self.panel_pixel_num_x = self.pixel_index_map.shape[1]
+            self.panel_pixel_num_y = self.pixel_index_map.shape[2]
 
         # total number of pixels (px*py)
         self.pixel_num_total = np.prod(self._shape)

--- a/pysingfel/detector/user_defined.py
+++ b/pysingfel/detector/user_defined.py
@@ -46,6 +46,9 @@ class UserDefinedDetector(DetectorBase):
         ##########################################################################################
 
         # Define the hierarchy system. For simplicity, we only use two-layer structure.
+        for key in {'panel number', 'panel pixel num x', 'panel pixel num y'}:
+            if key not in geom:
+                raise KeyError("Missing required '{}' key.".format(key))
         self.panel_num = int(geom['panel number'])
         self.panel_pixel_num_x = int(geom['panel pixel num x'])
         self.panel_pixel_num_y = int(geom['panel pixel num y'])
@@ -53,6 +56,9 @@ class UserDefinedDetector(DetectorBase):
                        self.panel_pixel_num_y)
 
         # Define all properties the detector should have
+        self.distance = None
+        if True:
+            self.center_x = xp.asarray(geom['pixel center x'], dtype=xp.float64)
         self.distance = float(geom['detector distance'])  # detector distance in (m)
 
         # Below: [panel number, pixel num x, pixel num y]  in (m)

--- a/pysingfel/detector/user_defined.py
+++ b/pysingfel/detector/user_defined.py
@@ -46,6 +46,8 @@ class UserDefinedDetector(DetectorBase):
 
         # Define the hierarchy system. For simplicity, we only use two-layer structure.
         self.panel_num = int(geom['panel number'])
+        self.panel_pixel_num_x = int(geom['panel pixel num x'])
+        self.panel_pixel_num_y = int(geom['panel pixel num y'])
 
         # Define all properties the detector should have
         self.distance = float(geom['detector distance'])  # detector distance in (m)

--- a/pysingfel/detector/user_defined.py
+++ b/pysingfel/detector/user_defined.py
@@ -72,8 +72,8 @@ class UserDefinedDetector(DetectorBase):
         # [panel number, pixel num x, pixel num y]
         self.pixel_index_map = xp.asarray(geom['pixel map'], dtype=xp.int64)
         # Detector pixel number info
-        self.detector_pixel_num_x = xp.max(self.pixel_index_map[:, :, :, 0])
-        self.detector_pixel_num_y = xp.max(self.pixel_index_map[:, :, :, 1])
+        self.detector_pixel_num_x = asnumpy(xp.max(self.pixel_index_map[:, :, :, 0]))
+        self.detector_pixel_num_y = asnumpy(xp.max(self.pixel_index_map[:, :, :, 1]))
 
         # Panel pixel number info
         # number of pixels in each panel in x/y direction

--- a/pysingfel/geometry/__init__.py
+++ b/pysingfel/geometry/__init__.py
@@ -141,7 +141,7 @@ def get_reciprocal_position_and_correction(pixel_position, pixel_area,
 
     # Because the pixel area in this function is measured in m^2,
     # therefore,the distance has to be in m
-    solid_angle_array = solid_angle(pixel_center=pixel_position * 1e-6,
+    solid_angle_array = solid_angle(pixel_center=pixel_position,
                                     pixel_area=pixel_area,
                                     orientation=orientation)
 


### PR DESCRIPTION
This PR repairs the UserDefinedDetector. This detector requires quite a lot of setup, so I also created a SimpleSquareDetector, which only requires the number of pixels, the detector dimensions, and the sample-detector distance.

I realized that the pixel_position was said to be in [m] but was actually in [µm]. They units were transformed correctly when used, but just put everything to [m] for consistency.

This PR also makes the detector shape (e.g. (4, 512, 512)) a property (`det.shape`).
It also makes the detector distance a property with a setter, which propagates the changes to the pixel position (real and reciprocal). The detector can therefore be moved with something like `det.distance *= 2`. This closes issue #46.