### PR TITLE
Fixing error in beam unit test

### DIFF
--- a/pysingfel/beam/tests/test_beam_base.py
+++ b/pysingfel/beam/tests/test_beam_base.py
@@ -140,6 +140,6 @@ def test_file():
     focus_x, focus_y, focus_shape = beam.get_focus()
     assert np.isclose(beam.photon_energy, 4600)
     assert np.isclose(beam.get_photons_per_pulse(), 1e12)
-    assert np.isclose(focus_x, 2e-7)
-    assert np.isclose(focus_y, 2e-7)
+    assert np.isclose(focus_x, 1e-6)
+    assert np.isclose(focus_y, 1e-6)
     assert focus_shape == "circle"


### PR DESCRIPTION
amo86615.beam lists beam/radius of 0.5e-6, so expected focus_x and focus_y values were updated to 1e-6. This resolves the unit test error from test_beam_base.test_file.