### PR TITLE
Skip autoranging unit test if psana2

### DIFF
--- a/pysingfel/detector/tests/test_autoranging_detector.py
+++ b/pysingfel/detector/tests/test_autoranging_detector.py
@@ -70,6 +70,7 @@ class TestAutorangingDetector(object):
         pattern = self.det.add_phase_shift(self.pattern_0, self.part_coord_1)
         assert np.allclose(pattern, self.pattern_1)
 
+    @pytest.mark.skipif(six.PY3, reason="Calibration constants require psana3")
     def test_pedestal_nonzero(self):
         """Test existence of pedestals."""
         assert np.sum(abs(self.det.pedestals[:])) > np.finfo(float).eps

--- a/pysingfel/detector/tests/test_autoranging_detector.py
+++ b/pysingfel/detector/tests/test_autoranging_detector.py
@@ -70,7 +70,7 @@ class TestAutorangingDetector(object):
         pattern = self.det.add_phase_shift(self.pattern_0, self.part_coord_1)
         assert np.allclose(pattern, self.pattern_1)
 
-    @pytest.mark.skipif(six.PY3, reason="Calibration constants require psana3")
+    @pytest.mark.skipif(six.PY3, reason="Calibration constants require psana2")
     def test_pedestal_nonzero(self):
         """Test existence of pedestals."""
         assert np.sum(abs(self.det.pedestals[:])) > np.finfo(float).eps


### PR DESCRIPTION
Skip unit test for existence of pedestals in TestAutorangingDetector if psana2 is in use, since epix10ka2M calibration constants are currently unavailable in the associated database.