### PR TITLE
Resolving discrepancy in SASE beam between mu and photon_energy

### DIFF
--- a/pysingfel/beam/sase.py
+++ b/pysingfel/beam/sase.py
@@ -12,6 +12,7 @@ class SASEBeam(Beam):
         self.mu = mu
         self.sigma = sigma
         self.n_spikes = n_spikes
+        self.photon_energy = mu
 
     def get_highest_wavenumber_beam(self):
         """

--- a/pysingfel/beam/sase.py
+++ b/pysingfel/beam/sase.py
@@ -9,10 +9,9 @@ class SASEBeam(Beam):
     def __init__(self, mu=None, sigma=None, n_spikes=0,
                  *args, **kargs):
         super(SASEBeam, self).__init__(**kargs)
-        self.mu = mu
+        self.photon_energy = mu
         self.sigma = sigma
         self.n_spikes = n_spikes
-        self.photon_energy = mu
 
     def get_highest_wavenumber_beam(self):
         """
@@ -33,13 +32,13 @@ class SASEBeam(Beam):
         # If simple Beam, return itself.
         # Variable beams should return simple one.
         n_samples = 100000
-        samples = np.random.normal(self.mu, self.sigma, self.n_spikes*n_samples)
+        samples = np.random.normal(self.photon_energy, self.sigma, self.n_spikes*n_samples)
 
         gkde = stats.gaussian_kde(samples)
 
         gkde.set_bandwidth(bw_method=0.25)
 
-        xs = np.linspace(self.mu-self.sigma*5, self.mu+self.sigma*5, self.n_spikes+1)
+        xs = np.linspace(self.photon_energy-self.sigma*5, self.photon_energy+self.sigma*5, self.n_spikes+1)
 
         density, bins, patches = plt.hist(samples, bins=xs, histtype=u'step', density=True)
 
@@ -47,7 +46,7 @@ class SASEBeam(Beam):
         density[ind[0][0]] *= 1.5
         density_renorm = density / density.sum()
 
-        photon_energy = np.linspace(self.mu-self.sigma*5, self.mu+self.sigma*5, self.n_spikes+1).tolist()
+        photon_energy = np.linspace(self.photon_energy-self.sigma*5, self.photon_energy+self.sigma*5, self.n_spikes+1).tolist()
         fluences = (self.get_photons_per_pulse()*density_renorm/density_renorm.sum())
 
         return [

--- a/pysingfel/geometry/generate.py
+++ b/pysingfel/geometry/generate.py
@@ -142,8 +142,7 @@ def get_random_rotation(rotation_axis=None):
         Otherwise the rotation is totally random.
     :return: A rotation matrix
     """
-    rotation_axis = rotation_axis.lower()
-    if rotation_axis in ('x', 'y', 'z'):
+    if rotation_axis is not None and rotation_axis.lower() in ('x', 'y', 'z'):
         u = np.random.rand() * 2 * np.pi  # random angle between [0, 2pi]
         return convert.angle_axis_to_rot3d(rotation_axis, u)
     else:


### PR DESCRIPTION
Setting up an instance of a SASE beam by running:

`sase_beam = ps.SASEBeam(mu=mu, sigma=sigma, n_spikes=n_spikes, fname=beam_file)`

results in a discrepancy between the photon_energy values of sase_beam and the individual spikes if mu and the wave parameter in beam_file don’t match. Since the former is used to determine the dimensions of the reciprocal space mesh while the latter is used to calculate diffraction patterns, an indexing error can result when calling experiment.get_image if the difference is large. The proposed change overwrites photon_energy to match the supplied mu, though all other parameters from beam_file are still used.