### PR TITLE
Fixing linspace/TypeError in build_particle_mesh()

### DIFF
--- a/pysingfel/particle.py
+++ b/pysingfel/particle.py
@@ -545,7 +545,7 @@ class Particle(object):
 
         linspace = np.linspace(-mesh_length/2.0,
                                 mesh_length/2.0,
-                                mesh_vertex_number_1d)
+                                int(mesh_vertex_number_1d))
         mesh_stack = np.asarray(np.meshgrid(linspace, linspace, linspace, indexing='ij'))
         mesh_stack = np.moveaxis(mesh_stack, 0, -1)
 


### PR DESCRIPTION
In the build_particle_mesh function, the variable mesh_vertex_number_1d was of type float, leading to a TypeError in using np.linspace in particle.py line 546. Casting mesh_vertex_number_1d as an int to avoid this problem.