### PR TITLE
Provisional fixes to radiationDamage scripts

### DIFF
--- a/pysingfel/detector/plain.py
+++ b/pysingfel/detector/plain.py
@@ -45,7 +45,7 @@ class PlainDetector(DetectorBase):
         self.panel_pixel_num_x = int(geom['pixel number x'])
         self.panel_pixel_num_y = int(geom['pixel number y'])
         self.pixel_num_total = np.array([self.panel_pixel_num_x * self.panel_pixel_num_y, ])
-        self.distance = np.array([geom['distance'], ])
+        self._distance = geom['distance']
 
         self.pixel_width = np.ones((self.panel_num,
                                     self.panel_pixel_num_x, self.panel_pixel_num_y)) * geom[
@@ -62,8 +62,8 @@ class PlainDetector(DetectorBase):
         self.pixel_position[0, ::, ::, 2] += self.distance
 
         # x,y direction position
-        total_length_x = (self.panel_pixel_num_x - 1) * self.pixel_width
-        total_length_y = (self.panel_pixel_num_y - 1) * self.pixel_height
+        total_length_x = (self.panel_pixel_num_x - 1) * geom[ 'pixel size x']
+        total_length_y = (self.panel_pixel_num_y - 1) * geom[ 'pixel size y']
 
         x_coordinate_temp = np.linspace(-total_length_x / 2, total_length_x / 2,
                                         num=self.panel_pixel_num_x,
@@ -79,8 +79,9 @@ class PlainDetector(DetectorBase):
         # Calculate the index map for the image
         mesh_temp = np.meshgrid(np.arange(self.panel_pixel_num_x),
                                 np.arange(self.panel_pixel_num_y))
-        self.pixel_index_map[0, :, :, 0] = mesh_temp[0][::, ::]
-        self.pixel_index_map[0, :, :, 1] = mesh_temp[1][::, ::]
+        p_map_x = np.stack((mesh_temp[0],))
+        p_map_y = np.stack((mesh_temp[1],))
+        self.pixel_index_map = np.stack((p_map_x, p_map_y), axis=-1)
         self.detector_pixel_num_x = self.panel_pixel_num_x
         self.detector_pixel_num_y = self.panel_pixel_num_y
 

--- a/pysingfel/detector/plain.py
+++ b/pysingfel/detector/plain.py
@@ -71,14 +71,14 @@ class PlainDetector(DetectorBase):
         y_coordinate_temp = np.linspace(-total_length_y / 2, total_length_y / 2,
                                         num=self.panel_pixel_num_y,
                                         endpoint=True)
-        mesh_temp = np.meshgrid(x_coordinate_temp, y_coordinate_temp)
+        mesh_temp = np.meshgrid(x_coordinate_temp, y_coordinate_temp, indexing='ij')
 
         self.pixel_position[0, ::, ::, 0] = mesh_temp[0][::, ::]
         self.pixel_position[0, ::, ::, 1] = mesh_temp[1][::, ::]
 
         # Calculate the index map for the image
         mesh_temp = np.meshgrid(np.arange(self.panel_pixel_num_x),
-                                np.arange(self.panel_pixel_num_y))
+                                np.arange(self.panel_pixel_num_y), indexing='ij')
         p_map_x = np.stack((mesh_temp[0],))
         p_map_y = np.stack((mesh_temp[1],))
         self.pixel_index_map = np.stack((p_map_x, p_map_y), axis=-1)

--- a/pysingfel/diffraction.py
+++ b/pysingfel/diffraction.py
@@ -22,13 +22,21 @@ def calculate_compton(particle, detector):
 
     :param particle: The particle object
     :param detector: The detector object
-    :return:
+    :return compton: Compton contribution in shape of detector array
     """
 
+    from scipy.interpolate import InterpolatedUnivariateSpline
     half_q = detector.pixel_distance_reciprocal * 1e-10 / 2.
 
-    cs = CubicSpline(particle.compton_q_sample, particle.sBound)
-    s_bound = cs(half_q)
+    # cubic interpolation for pixels in q-range of compton_q_sample
+    f = InterpolatedUnivariateSpline(particle.compton_q_sample, particle.sBound, k=3)
+    s_bound = f(half_q)
+    
+    # reduce inteprolation order for pixels that require extrapolation
+    f = InterpolatedUnivariateSpline(particle.compton_q_sample, particle.sBound, k=1)
+    extrapolate_indices = np.where(half_q>particle.compton_q_sample.max())
+    s_bound[extrapolate_indices] = f(half_q[extrapolate_indices])
+
     if isinstance(particle.nFree, (list, tuple, np.ndarray)):
         # if iterable, take first element to be number of free electrons
         n_free = particle.nFree[0]

--- a/pysingfel/diffraction.py
+++ b/pysingfel/diffraction.py
@@ -1,7 +1,6 @@
 import numpy as np
 from numba import jit
 from scipy.interpolate import CubicSpline
-from pysingfel.geometry import reshape_pixels_position_arrays_to_1d
 from pysingfel.util import xp, asnumpy
 
 
@@ -26,7 +25,7 @@ def calculate_compton(particle, detector):
     :return:
     """
 
-    half_q = reshape_pixels_position_arrays_to_1d(detector.pixel_distance_reciprocal * 1e-10 / 2.)
+    half_q = detector.pixel_distance_reciprocal * 1e-10 / 2.
 
     cs = CubicSpline(particle.compton_q_sample, particle.sBound)
     s_bound = cs(half_q)

--- a/pysingfel/particle.py
+++ b/pysingfel/particle.py
@@ -186,9 +186,9 @@ class Particle(object):
         :return:
         """
         with h5py.File(fname, 'r') as f:
-            atom_pos = f.get(datasetname + '/r').value  # atom position -> N x 3 array
+            atom_pos = f.get(datasetname + '/r')[()]  # atom position -> N x 3 array
             ion_list = f.get(
-                datasetname + '/xyz').value  # length = N, contain atom type id for each atom
+                datasetname + '/xyz')[()]  # length = N, contain atom type id for each atom
             self.atom_pos = atom_pos[np.argsort(ion_list)]
             self.center_and_align_according_to_principal_axes()
             _, idx = np.unique(np.sort(ion_list), return_index=True)
@@ -196,17 +196,17 @@ class Particle(object):
 
             # get atom factor table, sorted by atom type id
             atom_type = f.get(
-                datasetname + '/T').value  # atom type array, each type is represented by an integer
+                datasetname + '/T')[()]  # atom type array, each type is represented by an integer
             self.num_atom_types = len(atom_type)
-            ff_table = f.get(datasetname + '/ff').value
+            ff_table = f.get(datasetname + '/ff')[()]
             self.ff_table = ff_table[np.argsort(atom_type)]
 
-            self.q_sample = f.get(datasetname + '/halfQ').value
+            self.q_sample = f.get(datasetname + '/halfQ')[()]
             self.num_q_samples = len(self.q_sample)
-            self.compton_q_sample = f.get(datasetname + '/Sq_halfQ').value
+            self.compton_q_sample = f.get(datasetname + '/Sq_halfQ')[()]
             self.num_compton_q_samples = len(self.compton_q_sample)
-            self.sBound = f.get(datasetname + '/Sq_bound').value
-            self.nFree = f.get(datasetname + '/Sq_free').value
+            self.sBound = f.get(datasetname + '/Sq_bound')[()]
+            self.nFree = f.get(datasetname + '/Sq_free')[()]
 
         if center_and_align_according_to_principal_axes:
             self.center_and_align_according_to_principal_axes()
@@ -731,6 +731,6 @@ class Particle(object):
             for i in np.arange(3):
                 center[i] = 0.5*(np.max(self.atom_pos[:,i]) +
                                  np.min(self.atom_pos[:,i]))
-        elif mode is 'COM':
+        elif mode == 'COM':
             center = np.mean(self.atom_pos, axis=0)
         return center

--- a/pysingfel/radiationDamage.py
+++ b/pysingfel/radiationDamage.py
@@ -130,12 +130,8 @@ def make_one_diffr(myquaternions, counter, parameters, output_name):
     if not given_focus_radius:
         set_focus_from_file(input_name, beam)
 
-    det = PlainDetector(geom=geomfile, beam=beam)
-    #n_pixels, det_size, det_dist = 512, 0.1, 0.2 # temp fix due to error in PlainDetector
-    #det = SimpleSquareDetector(n_pixels, det_size, det_dist, beam=beam) # temp fix due to error in PlainDetector 
-    beam.set_photons_per_pulse(1e4 * beam.get_photons_per_pulse()) # temp fix until correct settings known
-
     # Detector geometry
+    det = PlainDetector(geom=geomfile, beam=beam)
     px = det.detector_pixel_num_x
     py = det.detector_pixel_num_x
 

--- a/pysingfel/radiationDamage.py
+++ b/pysingfel/radiationDamage.py
@@ -1,20 +1,20 @@
 from pysingfel.geometry import *
-from pysingfel.particle import rotate_particle, Particle
+from pysingfel.particle import Particle
 import h5py
 from pysingfel.detector import *
 from pysingfel.beam import *
 import pysingfel.util as pu
-from pysingfel.diffraction import calculate_compton, calculate_molecular_form_factor_square
+from pysingfel.diffraction import calculate_compton
 
 
 def generate_rotations(uniform_rotation, rotation_axis, num_quaternions):
     """
     Return quaternions saving the rotations to the particle.
 
-    :param uniform_rotation:
-    :param rotation_axis:
-    :param num_quaternions:
-    :return:
+    :param uniform_rotation: Bool, if True distribute points evenly
+    :param rotation_axis: rotation axis or 'xyz' if no preferred axis
+    :param num_quaternions: number of quaternions to generate
+    :return: quaternion list of shape [number of quaternion, 4]
     """
 
     if uniform_rotation is None:
@@ -26,11 +26,11 @@ def generate_rotations(uniform_rotation, rotation_axis, num_quaternions):
         return quaternions
 
     # Case uniform:
-    if uniform_rotation:
+    if uniform_rotation and num_quaternions!=1:
         if rotation_axis == 'y' or rotation_axis == 'z':
             return points_on_1sphere(num_quaternions, rotation_axis)
         elif rotation_axis == 'xyz':
-            return points_on_2sphere(num_quaternions)
+            return points_on_3sphere(num_quaternions)
     else:
         # Case non-uniform:
         quaternions = get_random_quat(num_quaternions)
@@ -41,9 +41,8 @@ def set_energy_from_file(fname, beam):
     """
     Set photon energy from pmi file.
 
-    :param fname:
-    :param beam:
-    :return:
+    :param fname: pmi file
+    :param beam: beam object
     """
 
     with h5py.File(fname, 'r') as f:
@@ -55,9 +54,8 @@ def set_focus_from_file(fname, beam):
     """
     Set beam focus from pmi file.
 
-    :param fname:
-    :param beam:
-    :return:
+    :param fname: pmi file
+    :param beam: beam object
     """
 
     with h5py.File(fname, 'r') as f:
@@ -70,11 +68,10 @@ def set_fluence_from_file(fname, time_slice, slice_interval, beam):
     """
     Set beam fluence from pmi file.
 
-    :param fname:
-    :param time_slice:
-    :param slice_interval:
-    :param beam:
-    :return:
+    :param fname: pmi file
+    :param time_slice: time of current calculation
+    :param slice_interval: interval for calculating photon field
+    :param beam: beam
     """
 
     n_phot = 0
@@ -90,11 +87,10 @@ def make_one_diffr(myquaternions, counter, parameters, output_name):
     Generate one diffraction pattern related to a certain rotation.
     Write results in output hdf5 file.
 
-    :param myquaternions:
-    :param counter:
-    :param parameters:
-    :param output_name:
-    :return:
+    :param myquaternions: list of quaternions
+    :param counter: index of diffraction pattern to compute
+    :param parameters: dictionary of command line arguments
+    :param output_name: path to h5 file for saving pattern
     """
 
     # Get parameters
@@ -102,8 +98,8 @@ def make_one_diffr(myquaternions, counter, parameters, output_name):
     num_dp = int(parameters['numDP'])
     num_slices = int(parameters['numSlices'])
     pmi_start_id = int(parameters['pmiStartID'])
-    pmi_id = pmi_start_id + counter / num_dp
-    slice_interval = int(parameters['slice_interval'])
+    pmi_id = int(pmi_start_id + counter / num_dp)
+    slice_interval = int(parameters['sliceInterval'])
     beamfile = parameters['beamFile']
     geomfile = parameters['geomFile']
     input_dir = parameters['inputDir']
@@ -119,7 +115,7 @@ def make_one_diffr(myquaternions, counter, parameters, output_name):
     if beam.get_photon_energy() > 0:
         given_photon_energy = True
     given_focus_radius = False
-    if beam.get_focus() > 0:
+    if (beam.get_focus()[0] > 0) and (beam.get_focus()[1] > 0):
         given_focus_radius = True
 
     # Setup quaternion.
@@ -134,7 +130,11 @@ def make_one_diffr(myquaternions, counter, parameters, output_name):
     if not given_focus_radius:
         set_focus_from_file(input_name, beam)
 
-    det = PlainDetector(geom=geomfile, beam=beam)
+    #det = PlainDetector(geom=geomfile, beam=beam)
+    n_pixels, det_size, det_dist = 512, 0.1, 0.2 # temp fix due to error in PlainDetector
+    det = SimpleSquareDetector(n_pixels, det_size, det_dist, beam=beam) # temp fix due to error in PlainDetector 
+    beam.set_photons_per_pulse(1e4 * beam.get_photons_per_pulse()) # temp fix until correct settings known
+
     # Detector geometry
     px = det.detector_pixel_num_x
     py = det.detector_pixel_num_x
@@ -142,7 +142,7 @@ def make_one_diffr(myquaternions, counter, parameters, output_name):
     done = False
     time_slice = 0
     total_phot = 0
-    detector_intensity = np.zeros((py, px))
+    detector_intensity = np.zeros((1, py, px))
     while not done:
         # set time slice to calculate diffraction pattern
         if time_slice + slice_interval >= num_slices:
@@ -153,23 +153,22 @@ def make_one_diffr(myquaternions, counter, parameters, output_name):
         # load particle information
         datasetname = '/data/snp_' + '{0:07}'.format(time_slice)
         particle = Particle(input_name, datasetname)
-        rotate_particle(quaternion, particle)
+        particle.rotate(quaternion)
         if not given_fluence:
             # sum up the photon fluence inside a slice_interval
             set_fluence_from_file(input_name, time_slice, slice_interval, beam)
         # Coherent contribution
-        f_hkl_sq = calculate_molecular_form_factor_square(particle=particle,
-                                                          q_space=det.pixel_distance_reciprocal,
-                                                          q_position=det.pixel_position_reciprocal)
+        f_hkl_sq = det.get_pattern_without_corrections(particle)
+
         # Incoherent contribution
         if consider_compton:
             compton = calculate_compton(particle, det)
         else:
-            compton = np.zeros((py, px))
+            compton = 0
         photon_field = f_hkl_sq + compton
         detector_intensity += photon_field*beam.get_photons_per_pulse_per_area()
     detector_intensity *= (det.solid_angle_per_pixel *
-                           det.polarization_correction)
+                           det.polarization_correction) * det.Thomson_factor
 
     detector_counts = np.random.poisson(detector_intensity)
     pu.save_as_diffr_outfile(output_name, input_name, counter,
@@ -182,16 +181,15 @@ def diffract(parameters):
     Calculate all the diffraction patterns based on the parameters provided as a dictionary.
     Save all results in one single file. Not used in MPI.
 
-    :param parameters:
-    :return:
+    :param parameters: dictionary of command line arguments
     """
 
     pmi_start_id = int(parameters['pmiStartID'])
     pmi_end_id = int(parameters['pmiEndID'])
     num_dp = int(parameters['numDP'])
     ntasks = (pmi_end_id - pmi_start_id + 1) * num_dp
-    rotation_axis = parameters['rotation_axis']
-    uniform_rotation = parameters['uniform_rotation']
+    rotation_axis = parameters['rotationAxis']
+    uniform_rotation = parameters['uniformRotation']
     myquaternions = generate_rotations(uniform_rotation, rotation_axis, ntasks)
     output_name = parameters['outputDir'] + '/diffr_out_0000001.h5'
     if os.path.exists(output_name):

--- a/pysingfel/radiationDamage.py
+++ b/pysingfel/radiationDamage.py
@@ -92,7 +92,7 @@ def get_dict_from_lines(reader):
 
     :params reader: An iterable that contains lists of strings in format [key, ' ', ' ', ..., value]
     :type: iterable (list, array, generator).
-
+    :return ret: A dictionary of beam-related parameters.
     """
     # These fields shall be handled as numeric data.
     numeric_keys = [
@@ -191,14 +191,8 @@ def make_one_diffr(myquaternions, counter, parameters, output_name):
     if beamfile is not None:
         beam = Beam(beamfile)
     else:
-        try:
-            # check whether current pmi file has beam information
-            beamfile = input_name
-            beam = initialize_beam_from_pmi(beamfile)
-        except TypeError:
-            # otherwise, extract beam information from first pmi file in the series
-            beamfile = input_dir + '/pmi_out_' + '{0:07}'.format(1) + '.h5'
-            beam = initialize_beam_from_pmi(beamfile)
+        beamfile = input_name
+        beam = initialize_beam_from_pmi(beamfile)
         given_fluence = False
 
     # Detector geometry

--- a/pysingfel/radiationDamage.py
+++ b/pysingfel/radiationDamage.py
@@ -17,7 +17,7 @@ def generate_rotations(uniform_rotation, rotation_axis, num_quaternions):
     :return: quaternion list of shape [number of quaternion, 4]
     """
 
-    if uniform_rotation is None:
+    if not uniform_rotation:
         # No rotation desired, init quaternions as (1,0,0,0)
         quaternions = np.empty((num_quaternions, 4))
         quaternions[:, 0] = 1.
@@ -130,9 +130,9 @@ def make_one_diffr(myquaternions, counter, parameters, output_name):
     if not given_focus_radius:
         set_focus_from_file(input_name, beam)
 
-    #det = PlainDetector(geom=geomfile, beam=beam)
-    n_pixels, det_size, det_dist = 512, 0.1, 0.2 # temp fix due to error in PlainDetector
-    det = SimpleSquareDetector(n_pixels, det_size, det_dist, beam=beam) # temp fix due to error in PlainDetector 
+    det = PlainDetector(geom=geomfile, beam=beam)
+    #n_pixels, det_size, det_dist = 512, 0.1, 0.2 # temp fix due to error in PlainDetector
+    #det = SimpleSquareDetector(n_pixels, det_size, det_dist, beam=beam) # temp fix due to error in PlainDetector 
     beam.set_photons_per_pulse(1e4 * beam.get_photons_per_pulse()) # temp fix until correct settings known
 
     # Detector geometry

--- a/pysingfel/radiationDamageMPI.py
+++ b/pysingfel/radiationDamageMPI.py
@@ -1,4 +1,4 @@
-import argparse
+import argparse, os
 
 from mpi4py import MPI
 
@@ -13,10 +13,7 @@ def main():
     :return:
     """
 
-    # Delete the first argument from the command line, which is the file name.
-    del sys.argv[0]
-    # Parse the input command line argumment to get parameters for simulation.
-    parameters = parse_input(sys.argv)
+    parameters = parse_input()
 
     # Initialize MPI
     comm = MPI.COMM_WORLD
@@ -40,7 +37,7 @@ def master_diffract(comm, parameters):
     Master node. Get the diffraction patterns with mpi
 
     :param comm: MPI comm
-    :param parameters:
+    :param parameters: dictionary of command line arguments
     :return:
     """
     pmi_start_id = int(parameters['pmiStartID'])
@@ -81,7 +78,7 @@ def slave_diffract(comm, parameters):
     Slave node. Get the diffraction patterns with mpi
 
     :param comm: MPI comm
-    :param parameters:
+    :param parameters: dictionary of command line arguments
     :return:
     """
     pmi_start_id = int(parameters['pmiStartID'])
@@ -113,12 +110,11 @@ def slave_diffract(comm, parameters):
         comm.send(counter, dest=0, tag=1)
 
 
-def parse_input(args):
+def parse_input():
     """
     Parse the input command arguments and return a dict containing all simulation parameters.
 
-    :param args:
-    :return:
+    :return parameters: dictionary of command-line arguments
     """
 
     # Instantiate the parser
@@ -127,8 +123,7 @@ def parse_input(args):
     parser.add_argument('--outputDir', help='Output directory for saving diffraction')
     parser.add_argument('--beamFile', help='Beam file defining X-ray beam')
     parser.add_argument('--geomFile', help='Geometry file defining diffraction geometry')
-    parser.add_argument('--configFile', help='Absolute path to the config file')
-    parser.add_argument('--rotationAxis', default='xyz', help='Euler rotation convention')
+    parser.add_argument('--rotationAxis', default='xyz', help='Preferred axis of rotation or xyz if none')
     parser.add_argument('--uniformRotation', type=parse_boolean,
                         help='If 1, rotates the sample uniformly in SO(3),\
                                 if 0 random orientation in SO(3),\
@@ -141,10 +136,9 @@ def parse_input(args):
     parser.add_argument('--pmiStartID', type=int, help='First Photon Matter Interaction (PMI) file ID to use')
     parser.add_argument('--pmiEndID', type=int, help='Last Photon Matter Interaction (PMI) file ID to use')
     parser.add_argument('--numDP', type=int, help='Number of diffraction patterns per PMI file')
-    parser.add_argument('--prepHDF5File', help='Absolute path to the prepHDF5.py script')
 
     # convert argparse to dict
-    return vars(parser.parse_args(args))
+    return vars(parser.parse_args())
 
 
 def parse_boolean(b):

--- a/pysingfel/util.py
+++ b/pysingfel/util.py
@@ -123,14 +123,17 @@ def read_geomfile(fname):
         for line in content:
             if line[0] != '#' and line[0] != ';' and len(line) > 1:
                 tmp = line.replace('=', ' ').split()
-                if tmp[0] == 'geom/d':
-                    geom.update({'distance': float(tmp[1])})
-                if tmp[0] == 'geom/pix_width':
-                    geom.update({'pixel size x': float(tmp[1])})
-                    geom.update({'pixel size y': float(tmp[1])})
-                if tmp[0] == 'geom/px':
-                    geom.update({'pixel number x': int(tmp[1])})
-                    geom.update({'pixel number y': int(tmp[1])})
+                if "geom" or "panel" in tmp[0]:
+                    if tmp[0].split("/")[1] == 'd':
+                        geom.update({'distance': float(tmp[1])})
+                    if tmp[0].split("/")[1] == 'pix_width':
+                        geom.update({'pixel size x': float(tmp[1])})
+                        geom.update({'pixel size y': float(tmp[1])})
+                    if tmp[0].split("/")[1] == 'px':
+                        geom.update({'pixel number x': int(tmp[1])})
+                        geom.update({'pixel number y': int(tmp[1])})
+            elif line[0] == '#' or line[0] == ';':
+                geom.update({'panel number': int(line.strip()[-1])})
 
     return geom
 


### PR DESCRIPTION
These changes permitted running radiationDamageMPI using the sample pmi_out_0000001.h5 file supplied in #96. Here are example output diffraction patterns, with the particle rotated to a new random orientation for each:

![download-1](https://user-images.githubusercontent.com/6363287/102693572-7660f200-41d0-11eb-8807-9b1d808bece1.png)

Unresolved issues:
1. PlainDetector doesn’t correctly load the sample .geom files. It’s unclear to me whether the Epix/pnCCD files are unsuitable for this class, or if changes to the .geom format have made PlainDetector outdated. A SimpleSquareDetector is used as a placeholder. Depending on the detector type used, an additional line to assemble_image_stack may be needed.
2. Should detector_intensity be scaled by the Thomson factor as in the linear corrections from the Detector class? 
3. Code should be checked for successful execution when multiple .h5 files are available.
4. A positive detector distance seems to lead to correct results for the particle's scattering, but I'm not sure if it's correct for the Compton scattering as well. See issue #110.