### PR TITLE
Functions for adding dark noise

### DIFF
--- a/pysingfel/detector/cspad.py
+++ b/pysingfel/detector/cspad.py
@@ -16,12 +16,13 @@ class CsPadDetector(LCLSDetector):
         from PSCalib.CalibParsBaseCSPadV1 import CalibParsBaseCSPadV1
         return CalibParsBaseCSPadV1()
 
-    def _get_det_id(self, source):
-        """Get detector ID form source.
+    def _get_det_id(self, group):
+        """Get detector ID form group.
 
-        Example: CsPad::CalibV1 -> CxiDs2.0:Cspad.0 => cspad_0002.
+        Example: CsPad::CalibV1 -> cspad_0001.
         Psana 2 only.
         """
-        match = re.match(r"CxiDs(\d)\.0:Cspad\.0", source)
+        match = re.match(r"CsPad::CalibV(\d)", group)
         number = str.zfill(match.groups()[0], 4)
         return "cspad_" + number
+

--- a/pysingfel/detector/lcls.py
+++ b/pysingfel/detector/lcls.py
@@ -3,7 +3,8 @@ import os
 import six
 import sys
 
-# support LCLSI-py2, LCLSI-py3 and LCLSII-py3
+# support LCLSI-py2 and LCLSII-py3
+# currently LCLSI-py3 is not supported
 try:
     if six.PY2:
         from PSCalib.GenericCalibPars import GenericCalibPars
@@ -25,12 +26,12 @@ from .base import DetectorBase
 
 class LCLSDetector(DetectorBase):
     """
-    Class for lcls detectors.
+    Class for LCLS detectors.
     """
 
     def __init__(self, geom, beam=None, run_num=0, cframe=0):
         """
-        Initialize a pnccd detector.
+        Initialize a LCLS detector.
 
         :param geom: The path to the geometry .data file.
         :param beam: The beam object.
@@ -65,8 +66,8 @@ class LCLSDetector(DetectorBase):
 
     def initialize(self, geom, run_num=0, cframe=0):
         """
-        Initialize the detector as pnccd
-        :param geom: The pnccd .data file which characterize the geometry profile.
+        Initialize the detector
+        :param geom: The *-end.data file which characterizes the geometry profile.
         :param run_num: The run_num containing the background, rms and gain and the other
                         pixel pixel properties.
         :param cframe: The desired coordinate frame, 0 for psana and 1 for lab conventions.
@@ -127,8 +128,11 @@ class LCLSDetector(DetectorBase):
         ###########################################################################################
         # first we should parse the path
         parsed_path = geom.split('/')
-        group = parsed_path[-4]
-        source = parsed_path[-3]
+        self.exp = parsed_path[-5]
+        if self.exp == 'calib':
+            self.exp = parsed_path[-6]
+        self.group = parsed_path[-4]
+        self.source = parsed_path[-3]
 
         self._pedestals = None
         self._pixel_rms = None
@@ -140,9 +144,9 @@ class LCLSDetector(DetectorBase):
         if six.PY2:
             try:
                 cbase = self._get_cbase()
-                calibdir = '/'.join(parsed_path[:-4])
+                self.calibdir = '/'.join(parsed_path[:-4])
                 pbits = 255
-                gcp = GenericCalibPars(cbase, calibdir, group, source, run_num, pbits)
+                gcp = GenericCalibPars(cbase, self.calibdir, self.group, self.source, run_num, pbits)
 
                 self._pedestals = gcp.pedestals()
                 self._pixel_rms = gcp.pixel_rms()
@@ -155,11 +159,10 @@ class LCLSDetector(DetectorBase):
                 pass
         else:
             try:
-                self.det = self._get_det_id(source)
+                self.det = self._get_det_id(self.group)
             except NotImplementedError:
                 # No GenericCalibPars information.
                 self.det = None
-            self.exp = parsed_path[-5]
 
         # Redirect the output stream
         sys.stdout = old_stdout
@@ -173,7 +176,7 @@ class LCLSDetector(DetectorBase):
         """
         raise NotImplementedError()
 
-    def _get_det_id(self, source):
+    def _get_det_id(self, group):
         """Get detector ID form source.
 
         Psana 2 only.
@@ -218,3 +221,197 @@ class LCLSDetector(DetectorBase):
     @property
     def pixel_gain(self):
         return self._get_calib_constants("pixel_gain")
+
+    @pedestals.setter
+    def pedestals(self, value):
+        self._pedestals = value
+
+    @pixel_rms.setter
+    def pixel_rms(self, value):
+        self._pixel_rms = value
+
+    @pixel_mask.setter
+    def pixel_mask(self, value):
+        self._pixel_mask = value
+
+    @pixel_bkgd.setter
+    def pixel_bkgd(self, value):
+        self._pixel_bkgd = value
+
+    @pixel_status.setter
+    def pixel_status(self, value):
+        self._pixel_status = value
+    
+    @pixel_gain.setter
+    def pixel_gain(self, value):
+        self._pixel_gain = value
+
+    def reset_calib(self, run_num):
+        """
+        Update calibration pixel effects based on new run number.
+        """
+        old_stdout = sys.stdout
+        f = six.StringIO()
+        sys.stdout = f
+
+        self.run_num = run_num
+        
+        if six.PY2:
+            try:
+                pbits = 255
+                gcp = GenericCalibPars(self._get_cbase(), self.calibdir, self.group, 
+                                       self.source, self.run_num, pbits)
+                self._pedestals = gcp.pedestals()
+                self._pixel_rms = gcp.pixel_rms()
+                self._pixel_mask = gcp.pixel_mask()
+                self._pixel_bkgd = gcp.pixel_bkgd()
+                self._pixel_status = gcp.pixel_status()
+                self._pixel_gain = gcp.pixel_gain()
+            except NotImplementedError:
+                pass
+        else:
+            self._pedestals = calib_constants(self.det, exp=self.exp, ctype='pedestals', run=self.run_num)[0]
+            self._pixel_rms = calib_constants(self.det, exp=self.exp, ctype='pixel_rms', run=self.run_num)[0]
+            self._pixel_mask = calib_constants(self.det, exp=self.exp, ctype='pixel_mask', run=self.run_num)[0]
+            self._pixel_bkgd = calib_constants(self.det, exp=self.exp, ctype='pixel_bkgd', run=self.run_num)[0]
+            self._pixel_status = calib_constants(self.det, exp=self.exp, ctype='pixel_status', run=self.run_num)[0]
+            self._pixel_gain = calib_constants(self.det, exp=self.exp, ctype='pixel_gain', run=self.run_num)[0]
+
+        sys.stdout = old_stdout
+
+        return
+
+    ###########################################################################################
+    # Functionality for adding dark noise
+    ###########################################################################################
+    def _calibrate_evt(self, evt):
+        """
+        Retrieve calibrated data from psana event object. Applied corrections are 
+        pedestal, common mode, gain mask, gain, and pixel status mask, performed
+        by the psana.Detector class.
+    
+        :param evt: psana event object
+        :return data: calibrated image
+        """    
+        import psana
+
+        # retrieve psana.Source alias
+        det_type = self.__class__.__name__.split("Detector")[0].lower()
+        alias = None
+    
+        for key in evt.keys():
+            if det_type in key.alias().lower():
+                alias = key.alias()
+                break
+            else:
+                srcname = key.src()
+                if srcname.__class__.__name__ == 'DetInfo':
+                    if det_type in srcname.devName().lower():
+                        alias = str(srcname)
+                        break
+
+        # retrieve calibrated shot
+        det = psana.Detector(alias)
+        return det.calib(evt)
+
+    def _retrieve_batch_evt(self, num_shots):
+        """
+        Retrieve num_shots patterns from a run of the experiment.
+        
+        :param num_shots: number of patterns to retrieve
+        :return data: array of patterns in shape (num_shots, n_pedestals, ped_x, ped_y)
+        """
+        # set up psana1 DataSource object
+        from psana import DataSource
+        ds = DataSource('exp=%s:run=%i' %(self.exp, self.run_num))
+    
+        # set up storage array
+        if self.pedestals.ndim == 4:
+            pshape = self.pedestals.shape[1:]
+        else:
+            pshape = self.pedestals.shape
+        data = np.zeros((num_shots, pshape[0], pshape[1], pshape[2]))
+
+        # retrieve multiple events (shots)
+        counter = 0
+        for num,evt in enumerate(ds.events()):
+            if counter < num_shots:
+                data[counter] = np.array(self._calibrate_evt(evt))
+                counter += 1
+            else:
+                break
+
+        # if run is shorter than num_shots, fill in remainder by linear combination
+        if counter < num_shots:
+            for i in range(counter, num_shots):
+                indices = np.random.randint(0, high=counter, size=2)
+                weights = np.random.dirichlet(np.ones(2))
+                data[i] = weights[0]*data[indices[0]] + weights[1]*data[indices[1]]
+            
+        return data
+
+    def _random_dark_index(self):
+        """
+        Return the run index of random dark run, assuming that the indices of dark
+        runs can be inferred from the pedestal nomenclature.
+        
+        :return dark_idx: index of random dark run, -1 if no dark runs available
+        """
+        import glob
+        
+        # list of available pedestals
+        pnames = glob.glob("/reg/d/psdm/%s/%s/calib/%s/%s/pedestals/*-end.data" %(self.exp[:3].upper(), self.exp, 
+                                                                                  self.group, self.source))
+
+        # add run indices from pedestals list if associated XTC files exist
+        dark_indices = list()
+        for pn in pnames:
+            temp_str = pn.split("/")[-1]
+            temp_idx = int(temp_str.split("-")[0])
+            fnames = glob.glob("/reg/d/psdm/%s/%s/xtc/*-r%04d-*.xtc" %(self.exp[:3].upper(), self.exp, temp_idx))
+            if len(fnames) > 0:
+                dark_indices.append(temp_idx)
+            
+        # return random dark run or -1 if none available
+        if len(dark_indices) != 0:
+            return np.random.choice(np.array(dark_indices))
+        else:
+            return -1
+            
+    def add_dark_noise(self, num_shots, det_shape=True, dark_idx=None, mask_neg=True):
+        """
+        Retrieve calibrated images from dark runs.
+    
+        :param num_shots: number of pedestal-subtracted dark shots to retreive
+        :param det_shape: boolean, if True reassemble panels into detector's shape
+        :param dark_idx: index of dark run; if None, a run number will be chosen randomly
+        :param mask_neg: boolean, if True mask any negative-valued pixels
+        :return dark_shots: array of pedestal-subtracted darks with shape 
+           (n_shots, det_x, det_y) if det_shape is True 
+           (n_shots, n_panels, panel_x, panel_y) if det_shape is False
+           None if pedestals and/or XTC files for a dark run are unavailable
+        """
+        if six.PY3:
+            raise NotImplementedError('Currently only implemented for psana2/python3.')
+            return
+
+        # grab index of random dark run and reset calibration attributes to match
+        if dark_idx == None:
+            dark_idx = self._random_dark_index()
+            if dark_idx == -1:
+                print("Pedestals and/or XTC data are unavailable.")
+                return
+        self.reset_calib(dark_idx)
+
+        # retrieve dark data
+        dark_data = self._retrieve_batch_evt(num_shots)
+
+        # floor: set negative intensities to zero
+        if mask_neg:
+            dark_data[dark_data<0] = 0
+    
+        # optionally reshape to match detector's shape
+        if det_shape:
+            dark_data = self.assemble_image_stack_batch(dark_data)
+        
+        return dark_data

--- a/pysingfel/detector/lcls.py
+++ b/pysingfel/detector/lcls.py
@@ -382,13 +382,13 @@ class LCLSDetector(DetectorBase):
         """
         Retrieve calibrated images from dark runs.
     
-        :param num_shots: number of pedestal-subtracted dark shots to retreive
+        :param num_shots: number of calibrated dark shots to retreive
         :param det_shape: boolean, if True reassemble panels into detector's shape
         :param dark_idx: index of dark run; if None, a run number will be chosen randomly
-        :param mask_neg: boolean, if True mask any negative-valued pixels
+        :param mask_neg: boolean, if True set negative-valued pixels to zero
         :return dark_data: array of calibrated dark shots with shape 
-           (n_shots, det_x, det_y) if det_shape is True 
-           (n_shots, n_panels, panel_x, panel_y) if det_shape is False
+           (num_shots, det_x, det_y) if det_shape is True 
+           (num_shots, n_panels, panel_x, panel_y) if det_shape is False
            None if pedestals and/or XTC files for a dark run are unavailable
         """
         if six.PY3:

--- a/pysingfel/detector/lcls.py
+++ b/pysingfel/detector/lcls.py
@@ -386,7 +386,7 @@ class LCLSDetector(DetectorBase):
         :param det_shape: boolean, if True reassemble panels into detector's shape
         :param dark_idx: index of dark run; if None, a run number will be chosen randomly
         :param mask_neg: boolean, if True mask any negative-valued pixels
-        :return dark_shots: array of pedestal-subtracted darks with shape 
+        :return dark_data: array of calibrated dark shots with shape 
            (n_shots, det_x, det_y) if det_shape is True 
            (n_shots, n_panels, panel_x, panel_y) if det_shape is False
            None if pedestals and/or XTC files for a dark run are unavailable

--- a/pysingfel/detector/pnccd.py
+++ b/pysingfel/detector/pnccd.py
@@ -16,12 +16,13 @@ class PnccdDetector(LCLSDetector):
         from PSCalib.CalibParsBasePnccdV1 import CalibParsBasePnccdV1
         return CalibParsBasePnccdV1()
 
-    def _get_det_id(self, source):
-        """Get detector ID form source.
+    def _get_det_id(self, group):
+        """Get detector ID form group.
 
-        Example: PNCCD::CalibV1 -> Camp.0:pnCCD.1 => pnccd_0001.
+        Example: PNCCD::CalibV1 -> pnccd_0001.
         Psana 2 only.
         """
-        match = re.match(r"Camp\.0:pnCCD\.(\d)", source)
+        match = re.match(r"PNCCD::CalibV(\d)", group)
         number = str.zfill(match.groups()[0], 4)
         return "pnccd_" + number
+


### PR DESCRIPTION
Functions have been added for retrieving calibrated dark shots from an experimental run. The calibration is done internally in psana1 and includes pedestal, common mode, gain, and pixel status corrections. The `add_dark_noise` function isn’t yet implemented for psana2; I’m not sure if the necessary calibration constants are available yet.

A few representative noise images for experiment cxic0415 follow. (The values look much better than what I showed earlier; I had mistakenly failed to match the pedestal and run numbers then.) I’ll add tests of this to the examples directory once CUDA is working again.

![darknoise](https://user-images.githubusercontent.com/6363287/106231632-fb173680-61a6-11eb-9384-0ecb8f8edb8c.png)
