### PR TITLE
adding pytests for example scripts

### DIFF
--- a/examples/scripts/ExampleAggregate.py
+++ b/examples/scripts/ExampleAggregate.py
@@ -9,7 +9,7 @@ from mpl_toolkits.mplot3d import Axes3D
 import matplotlib.pyplot as plt
 import pysingfel as ps
 from pysingfel.particlePlacement import *
-import time
+import time, os
 
 def drawSphere(xCenter, yCenter, zCenter, r):
     u, v = np.mgrid[0:2*np.pi:20j, 0:np.pi:10j]
@@ -25,7 +25,7 @@ def drawSphere(xCenter, yCenter, zCenter, r):
 num = 5
 
 # Input files
-input_dir='../input'
+input_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../input')
 beamfile=input_dir+'/beam/amo86615.beam'
 geom=input_dir+'/lcls/amo86615/PNCCD::CalibV1/Camp.0:pnCCD.1/geometry/0-end.data'
 pdbfile=input_dir+'/pdb/3iyf.pdb'
@@ -46,12 +46,10 @@ print('focus area = {}'.format(beam._focus_area))
 # Load and initialize the detector
 det = ps.PnccdDetector(geom=geom, beam=beam)
 increase_factor = 0.5
-print('BEFORE: detector distance = {} m'.format(np.abs(det.distance)))
+print('BEFORE: detector distance = {} m'.format(det.distance))
 print('>>> Increasing the detector distance by a factor of {}'.format(increase_factor))
-det.distance = increase_factor*np.abs(det.distance)
+det.distance = increase_factor*det.distance
 print('AFTER : detector distance = {} m'.format(det.distance))
-#det.distance = 0.3 # reset detector distance for desired resolution
-# Note: psana geometry used to be in psana coordinates and got changed to lab coordinates, add absolute value to make sure the detector distance is positive
 
 # Create particle object(s)
 particle = ps.Particle()
@@ -67,7 +65,7 @@ viz = ps.Visualizer(experiment, diffraction_rings="auto", log_scale=True)
 viz.imshow(img)
 plt.show()
 
-# Visalize particle sticking
+# Visualize particle sticking
 particle_group = experiment.generate_new_sample_state()
 part_positions = particle_group[0][0]
 radius = max_radius({particle: num})
@@ -86,7 +84,11 @@ r = np.ones(num)*radius
 
 fig = plt.figure()
 ax = fig.gca(projection='3d')
-ax.set_aspect('equal')
+try: 
+    ax.set_aspect('equal') # not implemented for all matplotlib versions
+except:
+    ax.set_aspect('auto')
+
 for (xi,yi,zi,ri) in zip(x,y,z,r):
     (xs,ys,zs) = drawSphere(xi,yi,zi,ri)
     ax.plot_wireframe(xs, ys, zs)

--- a/examples/scripts/ExampleAggregate.py
+++ b/examples/scripts/ExampleAggregate.py
@@ -5,6 +5,8 @@
 # In this example script, we demonstrate particle sticking/aggregation by introducing the variable attraction coefficient (gamma) into FXS experiment class. The interaction range between particle pairs is determined by this user-defined attraction coefficient (gamma), which ranges between 0 and 1. When gamma=1, particles stick together to form a large cluster.
 
 import numpy as np
+import matplotlib
+matplotlib.use('Agg')
 from mpl_toolkits.mplot3d import Axes3D
 import matplotlib.pyplot as plt
 import pysingfel as ps

--- a/examples/scripts/ExampleAutoranging.py
+++ b/examples/scripts/ExampleAutoranging.py
@@ -11,9 +11,10 @@ from pysingfel import *
 import pysingfel as ps
 from pysingfel.util import asnumpy, xp
 from pysingfel.build_autoranging_frames import BuildAutoRangeFrames
+import time, os
 
 # Input files
-input_dir='../input'
+input_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../input')
 beamfile=input_dir+'/beam/amo86615.beam'
 geom=input_dir+'/lcls/amo86615/PNCCD::CalibV1/Camp.0:pnCCD.1/geometry/0-end.data'
 pdbfile=input_dir+'/pdb/3iyf.pdb'
@@ -32,11 +33,10 @@ print('AFTER : # of photons per pulse = {}'.format(beam.get_photons_per_pulse())
 # Load and initialize the detector
 det = ps.Epix10kDetector(geom=geom, run_num=0, beam=beam, cameraConfig='fixedMedium')
 increase_factor = 0.5
-print('BEFORE: detector distance = {} m'.format(np.abs(det.distance)))
+print('BEFORE: detector distance = {} m'.format(det.distance))
 print('>>> Increasing the detector distance by a factor of {}'.format(increase_factor))
-det.distance = increase_factor*np.abs(det.distance)
+det.distance = increase_factor*det.distance
 print('AFTER : detector distance = {} m'.format(det.distance))
-#det.distance = 0.25 # reset detector distance for desired resolution
 
 # Create particle object(s)
 particle = ps.Particle()

--- a/examples/scripts/ExampleAutoranging.py
+++ b/examples/scripts/ExampleAutoranging.py
@@ -5,6 +5,8 @@
 # In this notebook, we demonstrate the LCLS-II autoranging detector effect by varying the characteristics of the beam, the type of the detector and its camera configuration.
 
 import numpy as np
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
 from pysingfel import *

--- a/examples/scripts/ExampleFXS.py
+++ b/examples/scripts/ExampleFXS.py
@@ -6,6 +6,8 @@
 # Input parameters including (1) beam, (2) detector, (3) particle(s) are needed for the FXS Experiment class.
 
 import numpy as np
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
 from mpl_toolkits.axes_grid1 import make_axes_locatable

--- a/examples/scripts/ExampleFXS.py
+++ b/examples/scripts/ExampleFXS.py
@@ -10,7 +10,7 @@ import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 import h5py as h5
-import time
+import time, os
 import pysingfel as ps
 
 # Parameters
@@ -19,7 +19,7 @@ numCl = 1
 num = 2
 
 # Input files
-input_dir='../input'
+input_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../input')
 beamfile=input_dir+'/beam/amo86615.beam'
 geom=input_dir+'/lcls/amo86615/PNCCD::CalibV1/Camp.0:pnCCD.1/geometry/0-end.data'
 pdbfile1=input_dir+'/pdb/3iyf.pdb'
@@ -36,11 +36,10 @@ print('AFTER : # of photons per pulse = {}'.format(beam.get_photons_per_pulse())
 # Load and initialize the detector
 det = ps.PnccdDetector(geom=geom, beam=beam)
 increase_factor = 0.5
-print('BEFORE: detector distance = {} m'.format(np.abs(det.distance)))
+print('BEFORE: detector distance = {} m'.format(det.distance))
 print('>>> Increasing the detector distance by a factor of {}'.format(increase_factor))
-det.distance = increase_factor*np.abs(det.distance)
+det.distance = increase_factor*det.distance
 print('AFTER : detector distance = {} m'.format(det.distance))
-#det.distance = 0.25 # reset detector distance for desired resolution
 
 # Create particle object(s)
 particleOp = ps.Particle()
@@ -54,7 +53,7 @@ tic = time.time()
 experiment = ps.FXSExperiment(det=det, beam=beam, jet_radius=1e-4, particles=[particleOp], n_part_per_shot=numOp, gamma=0.5)
 patternOp = experiment.generate_image_stack()
 toc = time.time()
-print(">>> It took {:.2f} seconds to finish SPI calculation.".format(toc-tic))
+print(">>> It took {:.2f} seconds to finish FXS calculation.".format(toc-tic))
 
 # Perform FXS experiment with one particle type
 experiment = ps.FXSExperiment(det=det, beam=beam, jet_radius=1e-4, particles=[particleCl], n_part_per_shot=numCl, gamma=0.5)

--- a/examples/scripts/ExampleHolography.py
+++ b/examples/scripts/ExampleHolography.py
@@ -9,9 +9,10 @@ from scipy import stats
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
 import pysingfel as ps
+import time, os
 
 # Input files
-input_dir='../input'
+input_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../input')
 beamfile=input_dir+'/beam/amo86615.beam'
 geom=input_dir+'/lcls/amo86615/PNCCD::CalibV1/Camp.0:pnCCD.1/geometry/0-end.data'
 pdbfile=input_dir+'/pdb/3iyf.pdb'
@@ -28,11 +29,10 @@ print('AFTER : # of photons per pulse = {}'.format(beam.get_photons_per_pulse())
 # Load and initialize the detector
 det = ps.PnccdDetector(geom=geom, beam=beam)
 increase_factor = 0.5
-print('BEFORE: detector distance = {} m'.format(np.abs(det.distance)))
+print('BEFORE: detector distance = {} m'.format(det.distance))
 print('>>> Increasing the detector distance by a factor of {}'.format(increase_factor))
-det.distance = increase_factor*np.abs(det.distance)
+det.distance = increase_factor*det.distance
 print('AFTER : detector distance = {} m'.format(det.distance))
-#det.distance = 0.25 # reset detector distance for desired resolution
 
 # Create particle object(s)
 particle = ps.Particle()
@@ -41,9 +41,12 @@ particle_2 = ps.Particle()
 particle_2.read_pdb(pdbfile2, ff='WK')
 
 # Perform Holography experiment
+tic = time.time()
 experiment = ps.HOLOExperiment(det, beam, [particle], [particle_2])
+toc = time.time()
+print(">>> It took {:.2f} seconds to finish Holography calculation.".format(toc-tic))
 
-# Visaulization
+# Visualization
 viz = ps.Visualizer(experiment, diffraction_rings="auto", log_scale=True)
 img = experiment.generate_image()
 viz.imshow(img)

--- a/examples/scripts/ExampleHolography.py
+++ b/examples/scripts/ExampleHolography.py
@@ -6,6 +6,8 @@
 
 import numpy as np
 from scipy import stats
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
 import pysingfel as ps

--- a/examples/scripts/ExampleHydration.py
+++ b/examples/scripts/ExampleHydration.py
@@ -5,6 +5,8 @@
 # In this notebook, we demonstrate the water surrounding effect by varying the thickness of the hydration layers with the orientation of the particle fixed.
 
 import numpy as np
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
 from mpl_toolkits.axes_grid1 import make_axes_locatable

--- a/examples/scripts/ExampleHydration.py
+++ b/examples/scripts/ExampleHydration.py
@@ -9,13 +9,11 @@ import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 import h5py as h5
-import time
-import sys
-sys.path.append('/cds/home/i/iris/pysingfel')
+import time, os
 import pysingfel as ps
 
 # Input files
-input_dir='../input'
+input_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../input')
 beamfile=input_dir+'/beam/amo86615.beam'
 geom=input_dir+'/lcls/amo86615/PNCCD::CalibV1/Camp.0:pnCCD.1/geometry/0-end.data'
 pdbfile=input_dir+'/pdb/3iyf.pdb'
@@ -32,12 +30,10 @@ print('photon energy = {} eV'.format(beam.photon_energy))
 # Load and initialize the detector
 det = ps.PnccdDetector(geom=geom, beam=beam)
 increase_factor = 0.5
-print('BEFORE: detector distance = {} m'.format(np.abs(det.distance)))
+print('BEFORE: detector distance = {} m'.format(det.distance))
 print('>>> Increasing the detector distance by a factor of {}'.format(increase_factor))
-det.distance = increase_factor*np.abs(det.distance)
+det.distance = increase_factor*det.distance
 print('AFTER : detector distance = {} m'.format(det.distance))
-#det.distance = 0.3 # reset detector distance for desired resolution
-# Note: psana geometry used to be in psana coordinates and got changed to lab coordinates, add absolute value to make sure the detector distance is positive
 
 # Create particle object(s)
 particle = ps.Particle()

--- a/examples/scripts/ExampleSASE.py
+++ b/examples/scripts/ExampleSASE.py
@@ -9,11 +9,11 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
 import h5py as h5
-import time
+import time, os
 import pysingfel as ps
 
 # Input files
-input_dir='../input'
+input_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../input')
 beamfile=input_dir+'/beam/amo86615.beam'
 geom=input_dir+'/lcls/amo86615/PNCCD::CalibV1/Camp.0:pnCCD.1/geometry/0-end.data'
 pdbfile=input_dir+'/pdb/3iyf.pdb'
@@ -32,12 +32,10 @@ print('AFTER : photon energy = {} eV'.format(beam.photon_energy))
 # Load and initialize the detector
 det = ps.PnccdDetector(geom=geom, beam=beam)
 increase_factor = 0.5
-print('BEFORE: detector distance = {} m'.format(np.abs(det.distance)))
+print('BEFORE: detector distance = {} m'.format(det.distance))
 print('>>> Increasing the detector distance by a factor of {}'.format(increase_factor))
-det.distance = increase_factor*np.abs(det.distance)
+det.distance = increase_factor*det.distance
 print('AFTER : detector distance = {} m'.format(det.distance))
-#det.distance = 0.3 # reset detector distance for desired resolution
-# Note: psana geometry used to be in psana coordinates and got changed to lab coordinates, add absolute value to make sure the detector distance is positive
 
 # Create particle object(s)
 particle = ps.Particle()

--- a/examples/scripts/ExampleSASE.py
+++ b/examples/scripts/ExampleSASE.py
@@ -6,6 +6,8 @@
 # To fix the particle orientation, set a random seed in get_random_quat in pysingfel/geometry/generate.py
 
 import numpy as np
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
 import h5py as h5

--- a/examples/scripts/ExampleSASESpectrum.py
+++ b/examples/scripts/ExampleSASESpectrum.py
@@ -11,7 +11,7 @@ from scipy import stats
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
 import h5py as h5
-import time
+import time, os
 import pysingfel as ps
 
 def wavelength_to_photon_energy(wavelength):
@@ -23,7 +23,7 @@ def wavelength_to_photon_energy(wavelength):
     return 1.2398e-06 / wavelength
 
 # Input files
-input_dir='../input'
+input_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../input')
 beamfile=input_dir+'/beam/amo86615.beam'
 
 # Load SASE spectra, with the mean photon energy = 7120eV

--- a/examples/scripts/ExampleSASESpectrum.py
+++ b/examples/scripts/ExampleSASESpectrum.py
@@ -8,6 +8,8 @@
 
 import numpy as np
 from scipy import stats
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
 import h5py as h5

--- a/examples/scripts/ExampleSPI.py
+++ b/examples/scripts/ExampleSPI.py
@@ -9,11 +9,11 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
 import h5py as h5
-import time
+import time, os
 import pysingfel as ps
 
 # Input files
-input_dir='../input'
+input_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../input')
 beamfile=input_dir+'/beam/amo86615.beam'
 geom=input_dir+'/lcls/amo86615/PNCCD::CalibV1/Camp.0:pnCCD.1/geometry/0-end.data'
 pdbfile=input_dir+'/pdb/3iyf.pdb'
@@ -30,12 +30,10 @@ print('photon energy = {} eV'.format(beam.photon_energy))
 # Load and initialize the detector
 det = ps.PnccdDetector(geom=geom, beam=beam)
 increase_factor = 0.5
-print('BEFORE: detector distance = {} m'.format(np.abs(det.distance)))
+print('BEFORE: detector distance = {} m'.format(det.distance))
 print('>>> Increasing the detector distance by a factor of {}'.format(increase_factor))
-det.distance = increase_factor*np.abs(det.distance)
+det.distance = increase_factor*det.distance
 print('AFTER : detector distance = {} m'.format(det.distance))
-#det.distance = 0.3 # reset detector distance for desired resolution
-# Note: psana geometry used to be in psana coordinates and got changed to lab coordinates, add absolute value to make sure the detector distance is positive
 
 # Create particle object(s)
 particle = ps.Particle()

--- a/examples/scripts/ExampleSPI.py
+++ b/examples/scripts/ExampleSPI.py
@@ -6,6 +6,8 @@
 # Input parameters including (1) beam, (2) detector, (3) particle(s) are needed for the SPI Experiment class.
 
 import numpy as np
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from matplotlib.colors import LogNorm
 import h5py as h5

--- a/examples/scripts/test_examples.py
+++ b/examples/scripts/test_examples.py
@@ -33,8 +33,8 @@ def test_example():
                 'Autoranging', 'Aggregate', 'Hydration']
 
     for exp in exp_list:
-        assert os.path.exists(os.path.join(ex_dir_, f'Example{exp}.py'))
-        command = ['python', os.path.join(ex_dir_, f'Example{exp}.py')]
+        assert os.path.exists(os.path.join(ex_dir_, 'Example%s.py' %exp))
+        command = ['python', os.path.join(ex_dir_, 'Example%s.py' %exp)]
         out, err, exitcode = capture(command)
         assert exitcode == 0
 

--- a/examples/scripts/test_examples.py
+++ b/examples/scripts/test_examples.py
@@ -1,0 +1,40 @@
+import pysingfel as ps
+import os, subprocess
+import numpy as np
+
+
+def capture(command):
+    """
+    Function for running an external script through subprocess module
+    and capturing results of the run. Code courtesy:
+    https://code-maven.com/slides/python/pytest-test-cli.
+
+    :param command: list of strings corresponding to command line call
+    :return out: stdout of command
+    :return err: stderr of command
+    :return returncode: exitcode, 0 for successful execution
+    """
+    proc = subprocess.Popen(command,
+                            stdout = subprocess.PIPE,
+                            stderr = subprocess.PIPE,
+                            )
+    out,err = proc.communicate()
+    return out, err, proc.returncode
+
+
+def test_example():
+    """
+    Test successful termination of select example scripts. Note that
+    correctness of the results is not checked.
+    """
+
+    ex_dir_ = os.path.join(os.path.dirname(__file__), '../../examples/scripts')
+    exp_list = ['SPI', 'FXS', 'Holography', 'SASE', 'SASESpectrum', 
+                'Autoranging', 'Aggregate', 'Hydration']
+
+    for exp in exp_list:
+        assert os.path.exists(os.path.join(ex_dir_, f'Example{exp}.py'))
+        command = ['python', os.path.join(ex_dir_, f'Example{exp}.py')]
+        out, err, exitcode = capture(command)
+        assert exitcode == 0
+

--- a/pysingfel/detector/lcls.py
+++ b/pysingfel/detector/lcls.py
@@ -3,18 +3,20 @@ import os
 import six
 import sys
 
-# support LCLSI-py2 and LCLSII-py3
-# currently LCLSI-py3 is not supported
+# support LCLSI-py2, LCLSI-py3, and LCLSII-py3
+global psana_version
 try:
-    if six.PY2:
-        from PSCalib.GenericCalibPars import GenericCalibPars
-        from PSCalib.GeometryAccess import GeometryAccess
-    else:
+    from PSCalib.GenericCalibPars import GenericCalibPars
+    from PSCalib.GeometryAccess import GeometryAccess
+    psana_version=1
+except Exception:
+    try:
         from psana.pscalib.geometry.GeometryAccess import GeometryAccess
         from psana.pscalib.calib.MDBWebUtils import calib_constants
-        
-except:
-    print("Psana functionality is not available.")
+        psana_version=2
+    except:
+        print("Psana functionality is not available.")
+        psana_version=0
 
 import pysingfel.geometry as pg
 import pysingfel.util as pu
@@ -141,7 +143,7 @@ class LCLSDetector(DetectorBase):
         self._pixel_status = None
         self._pixel_gain = None
 
-        if six.PY2:
+        if psana_version==1:
             try:
                 cbase = self._get_cbase()
                 self.calibdir = '/'.join(parsed_path[:-4])
@@ -186,7 +188,7 @@ class LCLSDetector(DetectorBase):
     def _get_calib_constants(self, name):
         _name = "_" + name
         attribute = getattr(self, _name)
-        if six.PY3 and attribute is None and self.det is not None:
+        if psana_version==2 and attribute is None and self.det is not None:
             # We haven't tried to get the calib_constant yet.
             attribute = calib_constants(
                 self.det, exp=self.exp, ctype=name,
@@ -256,7 +258,7 @@ class LCLSDetector(DetectorBase):
 
         self.run_num = run_num
         
-        if six.PY2:
+        if psana_version==1:
             try:
                 pbits = 255
                 gcp = GenericCalibPars(self._get_cbase(), self.calibdir, self.group, 
@@ -391,8 +393,8 @@ class LCLSDetector(DetectorBase):
            (num_shots, n_panels, panel_x, panel_y) if det_shape is False
            None if pedestals and/or XTC files for a dark run are unavailable
         """
-        if six.PY3:
-            raise NotImplementedError('Currently only implemented for psana2/python3.')
+        if psana_version==2:
+            raise NotImplementedError('Currently only implemented for psana2.')
             return
 
         # grab index of random dark run and reset calibration attributes to match

--- a/pysingfel/detector/tests/test_autoranging_detector.py
+++ b/pysingfel/detector/tests/test_autoranging_detector.py
@@ -7,13 +7,19 @@ import pysingfel.gpu as pg
 import pysingfel.constants as cst
 from pysingfel.build_autoranging_frames import BuildAutoRangeFrames
 
-import six
-if six.PY2:
-    PSCalib = pytest.importorskip("PSCalib")
-if six.PY3:
-    psana = pytest.importorskip("psana")
+global psana_version
+try:
+    from PSCalib.GeometryAccess import GeometryAccess
+    psana_version=1
+except Exception:
+    try:
+        from psana.pscalib.geometry.GeometryAccess import GeometryAccess
+        psana_version=2
+    except:
+        # psana unavailable; skip all AutorangingDetector tests
+        psana_version=0
 
-
+@pytest.mark.skipif(psana_version==0, reason='Autoranging detector requires psana')
 class TestAutorangingDetector(object):
     """Test autoranging detector functions."""
     @classmethod
@@ -70,7 +76,7 @@ class TestAutorangingDetector(object):
         pattern = self.det.add_phase_shift(self.pattern_0, self.part_coord_1)
         assert np.allclose(pattern, self.pattern_1)
 
-    @pytest.mark.skipif(six.PY3, reason="Calibration constants require psana2")
+    @pytest.mark.skipif(psana_version!=1, reason="Calibration constants require psana1")
     def test_pedestal_nonzero(self):
         """Test existence of pedestals."""
         assert np.sum(abs(self.det.pedestals[:])) > np.finfo(float).eps

--- a/pysingfel/experiment/holo.py
+++ b/pysingfel/experiment/holo.py
@@ -70,7 +70,7 @@ class HOLOExperiment(Experiment):
         Return the position.
         """
         if self._ref_position is None:
-            return None
+            return np.array([[0.,0.,0.]])
 
         ref_position = self._ref_position
 

--- a/pysingfel/experiment/holo.py
+++ b/pysingfel/experiment/holo.py
@@ -46,6 +46,8 @@ class HOLOExperiment(Experiment):
         part_positions = self.get_next_part_position()
         ref_orientation = self.get_ref_orientation()
         ref_position = self.get_ref_position()
+        if ref_position is None or ref_orientation is None:
+            raise TypeError("Missing reference particle orientation or position")
         positions = np.concatenate((ref_position,part_positions), axis=0)
         orientations = np.concatenate((ref_orientation,part_orientations), axis=0)
         particle_groups.append((positions, orientations))

--- a/pysingfel/geometry/tests/test_mapping.py
+++ b/pysingfel/geometry/tests/test_mapping.py
@@ -8,7 +8,7 @@ from pysingfel.util import xp
 
 def test_get_weight_and_index_center_odd():
     """Test get_weight_and_index centering for odd-sized meshes."""
-    pixel_position = xp.zeros((1,3), dtype=np.float)
+    pixel_position = xp.zeros((1,3), dtype=float)
     voxel_length = 1.
     voxel_num_1d = 5
     index, weight = mapping.get_weight_and_index(
@@ -20,7 +20,7 @@ def test_get_weight_and_index_center_odd():
 
 def test_get_weight_and_index_center_even():
     """Test get_weight_and_index centering for even-sized meshes."""
-    pixel_position = xp.zeros((1,3), dtype=xp.float)
+    pixel_position = xp.zeros((1,3), dtype=float)
     voxel_length = 1.
     voxel_num_1d = 4
     index, weight = mapping.get_weight_and_index(


### PR DESCRIPTION
Code has been added to test example scripts for successful termination (but not necessarily correctness); see issue #108. The example scripts were also modified to enable running them from a different folder and to not force a positive detector distance, since this is now ensured in the LCLSDetector class.